### PR TITLE
avoid slow dashboard_new_activities_count call on every request

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -212,15 +212,6 @@ class BaseController(WSGIController):
         self._identify_user()
         i18n.handle_request(request, c)
 
-        # If the user is logged in add their number of new activities to the
-        # template context.
-        if c.userobj:
-            from ckan.logic import get_action
-            new_activities_count = get_action(
-                'dashboard_new_activities_count')
-            context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author}
-            c.new_activities = new_activities_count(context, {})
 
     def _identify_user(self):
         '''


### PR DESCRIPTION
A similar change has been applied to ckan master (plus a deprecation warning) we never used the value being calculated.
