### PR TITLE
Address CKAN issue 2740: obviate sqlalchemy warning on IN clause operating on empty set

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1981,9 +1981,10 @@ def package_search(context, data_dict):
     for field_name in ('groups', 'organization'):
         group_names.extend(facets.get(field_name, {}).keys())
 
-    groups = session.query(model.Group.name, model.Group.title) \
-                    .filter(model.Group.name.in_(group_names)) \
-                    .all()
+    groups = (session.query(model.Group.name, model.Group.title)
+                     .filter(model.Group.name.in_(group_names))
+                     .all()
+              if len(group_names) else [])
     group_titles_by_name = dict(groups)
 
     # Transform facets into a more useful data structure.


### PR DESCRIPTION
When query filters through an IN clause having no candidates, short-circuit the result to the empty-list answer, obviating an sqlalchemy warning.