### PR TITLE
fix broken url on language toggle

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -357,6 +357,9 @@ def full_current_url():
     for sharing etc '''
     return (url_for(request.environ['CKAN_CURRENT_URL'], qualified=True))
 
+def current_url():
+    ''' Returns current url unquoted'''
+    return urllib.unquote(request.environ['CKAN_CURRENT_URL'])
 
 def lang():
     ''' Return the language code for the current locale eg `en` '''
@@ -2224,6 +2227,7 @@ __allowed_functions__ = [
     'debug_inspect',
     'dict_list_reduce',
     'full_current_url',
+    'current_url',
     'popular',
     'debug_full_info_as_list',
     'get_facet_title',

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -1,10 +1,9 @@
-{% set current_url = request.environ.CKAN_CURRENT_URL %}
 {% set current_lang = request.environ.CKAN_LANG %}
 <form class="form-inline form-select lang-select" action="{% url_for controller='util', action='redirect' %}" data-module="select-switch" method="POST">
   <label for="field-lang-select">{{ _('Language') }}</label>
   <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
     {% for locale in h.get_available_locales() %}
-      <option value="{% url_for current_url, locale=locale %}" {% if locale == current_lang %}selected="selected"{% endif %}>
+      <option value="{% url_for h.current_url(), locale=locale %}" {% if locale == current_lang %}selected="selected"{% endif %}>
         {{ locale.display_name or locale.english_name }}
       </option>
     {% endfor %}


### PR DESCRIPTION
Fixes #
if current url is /en/dataset?q=xxxx, then change to another language will generate bad url.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
