### PR TITLE
restrict anonymous access to user information, group member_list

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -714,9 +714,15 @@ class GroupController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user or c.author}
 
+        data_dict = {'id': id}
         try:
-            data_dict = {'id': id}
-            check_access('group_edit_permissions', context, data_dict)
+            check_access('group_show', context, data_dict)
+        except NotAuthorized:
+            abort(
+                403,
+                _('User %r not authorized to edit members of %s') % (
+                    c.user, id))
+        try:
             c.members = self._action('member_list')(
                 context, {'id': id, 'object_type': 'user'}
             )
@@ -724,11 +730,6 @@ class GroupController(base.BaseController):
             c.group_dict = self._action('group_show')(context, data_dict)
         except NotFound:
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(
-                403,
-                _('User %r not authorized to edit members of %s') % (
-                    c.user, id))
 
         return self._render_template('group/members.html', group_type)
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2214,6 +2214,10 @@ def sanitize_id(id_):
     return str(uuid.UUID(id_))
 
 
+def public_user_details():
+    return config.get('ckan.public_user_details', False)
+
+
 # these are the functions that will end up in `h` template helpers
 __allowed_functions__ = [
     # functions defined in ckan.lib.helpers
@@ -2338,4 +2342,5 @@ __allowed_functions__ = [
     'plugin_loaded',
     'clean_html',
     'sanitize_id',
+    'public_user_details',
 ]

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -8,6 +8,13 @@ from ckan.logic.auth import (
 )
 
 
+def restrict_anon(context):
+    if authz.auth_is_anon_user(context):
+        return {'success': False}
+    else:
+        return {'success': True}
+
+
 def sysadmin(context, data_dict):
     ''' This is a pseudo check if we are a sysadmin all checks are true '''
     return {'success': False, 'msg': _('Not authorized')}
@@ -112,7 +119,7 @@ def tag_list(context, data_dict):
 @logic.auth_read_safe
 def user_list(context, data_dict):
     # Users list is visible by default
-    return {'success': True}
+    return restrict_anon(context)
 
 
 @logic.auth_read_safe
@@ -230,8 +237,6 @@ def revision_show(context, data_dict):
 def group_show(context, data_dict):
     user = context.get('user')
     group = get_group_object(context, data_dict)
-    if group.state == 'active':
-        return {'success': True}
     authorized = authz.has_user_permission_for_group_or_org(
         group.id, user, 'read')
     if authorized:
@@ -267,7 +272,7 @@ def tag_show(context, data_dict):
 def user_show(context, data_dict):
     # By default, user details can be read by anyone, but some properties like
     # the API key are stripped at the action level if not not logged in.
-    return {'success': True}
+    return restrict_anon(context)
 
 
 @logic.auth_read_safe

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -6,6 +6,7 @@ from ckan.logic.auth import (
     get_group_object,
     get_resource_object
 )
+import ckan.lib.helpers as h
 
 
 def restrict_anon(context):
@@ -119,7 +120,10 @@ def tag_list(context, data_dict):
 @logic.auth_read_safe
 def user_list(context, data_dict):
     # Users list is visible by default
-    return restrict_anon(context)
+    if not h.public_user_details():
+        return restrict_anon(context)
+    else:
+        return {'success': True}
 
 
 @logic.auth_read_safe
@@ -272,7 +276,10 @@ def tag_show(context, data_dict):
 def user_show(context, data_dict):
     # By default, user details can be read by anyone, but some properties like
     # the API key are stripped at the action level if not not logged in.
-    return restrict_anon(context)
+    if not h.public_user_details():
+        return restrict_anon(context)
+    else:
+        return {'success': True}
 
 
 @logic.auth_read_safe


### PR DESCRIPTION
Fixes #
CKAN API allows anonymous access to user_list and user_show, member_list.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
