### PR TITLE
login: remove flash error for invalid login

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -395,7 +395,7 @@ class UserController(base.BaseController):
             item.login()
 
         if 'error' in request.params:
-            h.flash_error(request.params['error'])
+            error = request.params['error']
 
         if not c.user:
             came_from = request.params.get('came_from')

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -394,7 +394,11 @@ class UserController(base.BaseController):
         for item in p.PluginImplementations(p.IAuthenticator):
             item.login()
 
-        if 'error' in request.params:
+        if error is None and 'error' in request.params:
+            # if no value is provided for error but request parameters have error
+            # then set error value same as request parameters
+            # pass error to template instead of with flash_error
+            # so it can be captured for GA events in our overridden templates
             error = request.params['error']
 
         if not c.user:


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Remove flash warning for login and assign to error variable which would be passed to render

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
