### PR TITLE
upload: add filesize on create/edit resource

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -3,6 +3,7 @@
 '''API functions for adding data to CKAN.'''
 
 import logging
+import os
 import random
 import re
 from socket import error as socket_error
@@ -295,6 +296,12 @@ def resource_create(context, data_dict):
         pkg_dict['resources'] = []
 
     upload = uploader.get_resource_uploader(data_dict)
+
+    # determine size for the file to upload
+    if upload.filename:
+        upload.upload_file.seek(0, 2)
+        data_dict['size'] = upload.upload_file.tell()
+        upload.upload_file.seek(0, 0)
 
     pkg_dict['resources'].append(data_dict)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -96,6 +96,15 @@ def resource_update(context, data_dict):
 
     upload = uploader.get_resource_uploader(data_dict)
 
+    if upload.filename:
+        # determine size for the file to upload
+        upload.upload_file.seek(0, 2)
+        data_dict['size'] = upload.upload_file.tell()
+        upload.upload_file.seek(0, 0)
+    elif upload.clear:
+        # remove file size if clear is set
+        data_dict['size'] = ''
+
     pkg_dict['resources'][n] = data_dict
 
     try:


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Add file size of uploaded file to resource on create and edit 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
