### PR TITLE
OPN-1659: datatables view - fix conflict with organization name

### DIFF
--- a/ckan/public/base/javascript/view-filters.js
+++ b/ckan/public/base/javascript/view-filters.js
@@ -89,9 +89,9 @@ this.ckan.views.filters = (function (queryString) {
         if (!$.isArray(fields)) {
           fields = [fields];
         }
-
+        // Encode ':' and '|' as '#:' and '#|' to avoid conflicts when splitting filters.
         var fieldsStr = $.map(fields, function (field) {
-          return filter + ':' + field;
+          return filter.replace(/(?<!#):/g, '#:') + ':' + field.replace(/(?<!#)\|/g, '#|').replace(/(?<!#):/g, '#:');
         });
 
         return fieldsStr.join('|');
@@ -128,12 +128,12 @@ this.ckan.views.filters = (function (queryString) {
 
     if (searchParams.filters) {
       var filters = {},
-          fieldValuesStr = String(searchParams.filters).split('|'),
+          fieldValuesStr = String(searchParams.filters).split(/(?<!#)\|/g),
           i,
           len;
 
       for (i = 0, len = fieldValuesStr.length; i < len; i++) {
-        var fieldValue = fieldValuesStr[i].match(/([^:]+):(.*)/),
+        var fieldValue = fieldValuesStr[i].replace(/#:/g, ':').match(/([^:]+):(.*)/),
             field = fieldValue[1],
             value = fieldValue[2];
 

--- a/ckan/public/base/javascript/view-filters.js
+++ b/ckan/public/base/javascript/view-filters.js
@@ -128,7 +128,7 @@ this.ckan.views.filters = (function (queryString) {
 
     if (searchParams.filters) {
       var filters = {},
-          fieldValuesStr = String(searchParams.filters).split('~'),
+          fieldValuesStr = String(searchParams.filters).split('|'),
           i,
           len;
 

--- a/ckan/public/base/javascript/view-filters.js
+++ b/ckan/public/base/javascript/view-filters.js
@@ -128,7 +128,7 @@ this.ckan.views.filters = (function (queryString) {
 
     if (searchParams.filters) {
       var filters = {},
-          fieldValuesStr = String(searchParams.filters).split('|'),
+          fieldValuesStr = String(searchParams.filters).split('~'),
           i,
           len;
 

--- a/ckanext/datatablesview/controller.py
+++ b/ckanext/datatablesview/controller.py
@@ -6,6 +6,7 @@ from six import text_type
 
 from ckan.plugins.toolkit import BaseController, get_action, request, h
 from ckan.common import json
+import re
 
 
 class DataTablesController(BaseController):
@@ -18,7 +19,7 @@ class DataTablesController(BaseController):
         offset = int(request.params['start'])
         limit = int(request.params['length'])
         view_filters = resource_view.get(u'filters', {})
-        user_filters = text_type(request.params['filters'])
+        user_filters = text_type(request.params['filters']) 
         filters = merge_filters(view_filters, user_filters)
 
         datastore_search = get_action(u'datastore_search')
@@ -52,6 +53,7 @@ class DataTablesController(BaseController):
             u"sort": u', '.join(sort_list),
             u"filters": filters,
         })
+
 
         return json.dumps({
             u'draw': draw,
@@ -126,10 +128,27 @@ def merge_filters(view_filters, user_filters_str):
     if not user_filters_str:
         return filters
     user_filters = {}
-    for k_v in user_filters_str.split(u'|'):
+
+    updated_user_filters = reformat_user_filters(user_filters_str)
+
+    for k_v in updated_user_filters.split(u'~'):
         k, sep, v = k_v.partition(u':')
         if k not in view_filters or v in view_filters[k]:
             user_filters.setdefault(k, []).append(v)
     for k in user_filters:
         filters[k] = user_filters[k]
     return filters
+
+# TODO Remove this workaround when organization field uses scheming extension
+# This changes the character to split from | to ~ to avoid conflict with organization name
+def reformat_user_filters(filters):
+    
+    updated_filters = filters.replace('|', '~')
+    try:
+        for org_idx in [m.start() for m in re.finditer('Organization / Organisation', updated_filters)]:
+            idx = updated_filters.find('~', org_idx)
+            updated_filters = updated_filters[:idx] + '|' + updated_filters[idx+1:]
+    except ValueError:
+        return updated_filters
+    
+    return updated_filters

--- a/ckanext/datatablesview/controller.py
+++ b/ckanext/datatablesview/controller.py
@@ -6,6 +6,7 @@ from six import text_type
 
 from ckan.plugins.toolkit import BaseController, get_action, request, h
 from ckan.common import json
+import re
 
 
 class DataTablesController(BaseController):
@@ -126,8 +127,13 @@ def merge_filters(view_filters, user_filters_str):
     if not user_filters_str:
         return filters
     user_filters = {}
-    for k_v in user_filters_str.split(u'|'):
-        k, sep, v = k_v.partition(u':')
+
+    #Decode '#:' and '#|' as ':' and '|' to avoid conflicts when splitting filters.
+    for k_v in re.split(r'(?<!#)\|', user_filters_str):
+        k_v = k_v.replace('#|', '|')
+        k, v = re.split(r'(?<!#):', k_v)
+        k = k.replace('#:', ':')
+        v = v.replace('#:', ':')
         if k not in view_filters or v in view_filters[k]:
             user_filters.setdefault(k, []).append(v)
     for k in user_filters:


### PR DESCRIPTION
A workaround to get the datatables extension split and merge user filters using something other than "|" so it doesn't conflict with the "|" in the filter values of our organization names.