### PR TITLE
Added locale to redirect_to helper. Made use of it in the calls in re…

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -383,7 +383,7 @@ class UserController(base.BaseController):
                 # Changing currently logged in user's name.
                 # Update repoze.who cookie to match
                 set_repoze_user(data_dict['name'])
-            h.redirect_to(controller='user', action='read', id=user['name'], locale=h.lang())
+            h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
             abort(403, _('Unauthorized to edit user %s') % id)
         except NotFound as e:
@@ -417,7 +417,7 @@ class UserController(base.BaseController):
                 vars = {}
             return render('user/login.html', extra_vars=vars)
         else:
-            return h.redirect_to(controller='user', action='logged_in', locale=h.lang())
+            return h.redirect_to(controller='user', action='logged_in')
 
     def logged_in(self):
         # redirect if needed

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -512,6 +512,7 @@ class UserController(base.BaseController):
                         _(u'Error sending the email. Try again later '
                           'or contact an administrator for help')
                     )
+                    log.exception(e)
                     return h.redirect_to(u'/', locale=h.lang())
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -383,7 +383,7 @@ class UserController(base.BaseController):
                 # Changing currently logged in user's name.
                 # Update repoze.who cookie to match
                 set_repoze_user(data_dict['name'])
-            h.redirect_to(controller='user', action='read', id=user['name'])
+            h.redirect_to(controller='user', action='read', id=user['name'], locale=h.lang())
         except NotAuthorized:
             abort(403, _('Unauthorized to edit user %s') % id)
         except NotFound as e:
@@ -417,7 +417,7 @@ class UserController(base.BaseController):
                 vars = {}
             return render('user/login.html', extra_vars=vars)
         else:
-            return h.redirect_to(controller='user', action='logged_in')
+            return h.redirect_to(controller='user', action='logged_in', locale=h.lang())
 
     def logged_in(self):
         # redirect if needed
@@ -512,14 +512,13 @@ class UserController(base.BaseController):
                         _(u'Error sending the email. Try again later '
                           'or contact an administrator for help')
                     )
-                    log.exception(e)
-                    return h.redirect_to(u'/')
+                    return h.redirect_to(u'/', locale=h.lang())
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not
             h.flash_success(
                 _(u'A reset link has been emailed to you '
                   '(unless the account specified does not exist)'))
-            return h.redirect_to(u'/')
+            return h.redirect_to(u'/', locale=h.lang())
         return render('user/request_reset.html')
 
     def perform_reset(self, id):

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -513,13 +513,13 @@ class UserController(base.BaseController):
                           'or contact an administrator for help')
                     )
                     log.exception(e)
-                    return h.redirect_to(u'/', locale=h.lang())
+                    return h.redirect_to(u'/')
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not
             h.flash_success(
                 _(u'A reset link has been emailed to you '
                   '(unless the account specified does not exist)'))
-            return h.redirect_to(u'/', locale=h.lang())
+            return h.redirect_to(u'/')
         return render('user/request_reset.html')
 
     def perform_reset(self, id):

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -472,7 +472,7 @@ class UserController(base.BaseController):
             id = request.params.get('user')
             if id in (None, u''):
                 h.flash_error(_(u'Email is required'))
-                return h.redirect_to(u'/user/reset')
+                return h.redirect_to(u'user.request_reset')
             context = {'model': model,
                        'user': c.user,
                        u'ignore_auth': True}
@@ -513,13 +513,13 @@ class UserController(base.BaseController):
                           'or contact an administrator for help')
                     )
                     log.exception(e)
-                    return h.redirect_to(u'/')
+                    return h.redirect_to(u'user.login')
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not
             h.flash_success(
                 _(u'A reset link has been emailed to you '
                   '(unless the account specified does not exist)'))
-            return h.redirect_to(u'/')
+            return h.redirect_to(u'user.login')
         return render('user/request_reset.html')
 
     def perform_reset(self, id):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -189,8 +189,12 @@ def redirect_to(*args, **kw):
     if skip_url_parsing is False:
         _url = url_for(*uargs, **kw)
 
+    locale = kw.pop('locale', '')
+    if len(locale) > 0:
+        locale = "/" + locale
+
     if _url.startswith('/'):
-        _url = str(config['ckan.site_url'].rstrip('/') + _url)
+        _url = str(config['ckan.site_url'].rstrip('/') + locale + _url)
 
     if is_flask_request():
         return _flask_redirect(_url)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -190,7 +190,7 @@ def redirect_to(*args, **kw):
         _url = url_for(*uargs, **kw)
 
     locale = kw.pop('locale', '')
-    if len(locale) > 0:
+    if locale:
         locale = "/" + locale
 
     if _url.startswith('/'):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -189,12 +189,8 @@ def redirect_to(*args, **kw):
     if skip_url_parsing is False:
         _url = url_for(*uargs, **kw)
 
-    locale = kw.pop('locale', '')
-    if locale:
-        locale = "/" + locale
-
     if _url.startswith('/'):
-        _url = str(config['ckan.site_url'].rstrip('/') + locale + _url)
+        _url = str(config['ckan.site_url'].rstrip('/') + _url)
 
     if is_flask_request():
         return _flask_redirect(_url)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -568,14 +568,14 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'/')
+                return h.redirect_to(u'/', locale=h.lang())
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'/')
+        return h.redirect_to(u'/', locale=h.lang())
 
     def get(self):
         self._prepare()

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -514,7 +514,7 @@ class RequestResetView(MethodView):
         id = request.form.get(u'user')
         if id in (None, u''):
             h.flash_error(_(u'Email is required'))
-            return h.redirect_to(u'/user/reset')
+            return h.redirect_to(u'/user/reset', locale=h.lang())
         log.info(u'Password reset requested for user "{}"'.format(id))
 
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -514,7 +514,7 @@ class RequestResetView(MethodView):
         id = request.form.get(u'user')
         if id in (None, u''):
             h.flash_error(_(u'Email is required'))
-            return h.redirect_to(u'/user/reset', locale=h.lang())
+            return h.redirect_to(u'user.request_reset')
         log.info(u'Password reset requested for user "{}"'.format(id))
 
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}
@@ -568,14 +568,14 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'/', locale=h.lang())
+                return h.redirect_to(u'user.login')
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'/', locale=h.lang())
+        return h.redirect_to(u'user.login')
 
     def get(self):
         self._prepare()


### PR DESCRIPTION
…quest_reset.

Fixes #

Password reset form redirect does not maintain current locale. It just redirects to "/". Added locale to helper method and made use of it in request_reset redirects. This is just a small hot fix which will most likely e removed soon from the upgrade to ckan2.9

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
- [X] None of the above

Please [X] all the boxes above that apply
