### PR TITLE
Added `ckan.record_private_activity` check for private package activi…

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -220,7 +220,7 @@ def package_create(context, data_dict):
             {'package': data})
 
     # Create activity
-    if not pkg.private:
+    if not pkg.private or config.get('ckan.record_private_activity', False):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -28,7 +28,7 @@ import ckan.lib.datapreview
 import ckan.lib.api_token as api_token
 import ckan.authz as authz
 
-from ckan.common import _, config
+from ckan.common import _, config, asbool
 
 # FIXME this looks nasty and should be shared better
 from ckan.logic.action.update import _update_package_relationship
@@ -220,7 +220,7 @@ def package_create(context, data_dict):
             {'package': data})
 
     # Create activity
-    if not pkg.private or config.get('ckan.record_private_activity', False):
+    if not pkg.private or asbool(config.get('ckan.record_private_activity', False)):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -16,7 +16,7 @@ import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.api_token as api_token
 from ckan import authz
 
-from ckan.common import _, config
+from ckan.common import _, config, asbool
 
 
 log = logging.getLogger('ckan.logic')
@@ -115,7 +115,7 @@ def package_delete(context, data_dict):
         collaborator.delete()
 
     # Create activity
-    if not entity.private  or config.get('ckan.record_private_activity', False):
+    if not entity.private or asbool(config.get('ckan.record_private_activity', False)):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -16,7 +16,7 @@ import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.api_token as api_token
 from ckan import authz
 
-from ckan.common import _
+from ckan.common import _, config
 
 
 log = logging.getLogger('ckan.logic')
@@ -115,7 +115,7 @@ def package_delete(context, data_dict):
         collaborator.delete()
 
     # Create activity
-    if not entity.private:
+    if not entity.private  or config.get('ckan.record_private_activity', False):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -29,7 +29,7 @@ import ckan.lib.datapreview
 import ckan.lib.app_globals as app_globals
 
 
-from ckan.common import _, request
+from ckan.common import _, request, asbool
 
 log = logging.getLogger(__name__)
 
@@ -362,7 +362,7 @@ def package_update(context, data_dict):
         item.after_update(context, data)
 
     # Create activity
-    if not pkg.private  or config.get('ckan.record_private_activity', False):
+    if not pkg.private or asbool(config.get('ckan.record_private_activity', False)):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -362,7 +362,7 @@ def package_update(context, data_dict):
         item.after_update(context, data)
 
     # Create activity
-    if not pkg.private:
+    if not pkg.private  or config.get('ckan.record_private_activity', False):
         user_obj = model.User.by_name(user)
         if user_obj:
             user_id = user_obj.id


### PR DESCRIPTION
…ty stream item creations.

Fixes #

Adds `ckan.record_private_activity` check to allow for private package activity streams. Default is still `False` (no activity streams for private packages)

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
