### PR TITLE
Added `include_translated` option to `organizations_available` helper…

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -33,8 +33,7 @@ def group_list_dictize(obj_list, context,
                        with_package_counts=True,
                        include_groups=False,
                        include_tags=False,
-                       include_extras=False,
-                       include_translated=False):
+                       include_extras=False):
 
     group_dictize_context = dict(context.items())
     # Set options to avoid any SOLR queries for each group, which would
@@ -45,7 +44,6 @@ def group_list_dictize(obj_list, context,
             'include_groups': include_groups,
             'include_tags': include_tags,
             'include_extras': include_extras,
-            'include_translated': include_translated,
             'include_users': False,  # too slow - don't allow
             }
     if with_package_counts and 'dataset_counts' not in group_dictize_context:
@@ -292,7 +290,6 @@ def group_dictize(group, context,
                   include_tags=True,
                   include_users=True,
                   include_extras=True,
-                  include_translated=True,
                   packages_field='datasets',
                   **kw):
     '''
@@ -314,14 +311,6 @@ def group_dictize(group, context,
     if include_extras:
         result_dict['extras'] = extras_dict_dictize(
             group._extras, context)
-
-    if include_translated:
-        translated_dict = translated_dict_dictize(
-            group._extras, context)
-
-        for translated in translated_dict:
-            if translated['key'] not in result_dict:
-                result_dict[translated['key']] = translated['value']
 
     context['with_capacity'] = True
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -33,7 +33,8 @@ def group_list_dictize(obj_list, context,
                        with_package_counts=True,
                        include_groups=False,
                        include_tags=False,
-                       include_extras=False):
+                       include_extras=False,
+                       include_translated=False):
 
     group_dictize_context = dict(context.items())
     # Set options to avoid any SOLR queries for each group, which would
@@ -44,6 +45,7 @@ def group_list_dictize(obj_list, context,
             'include_groups': include_groups,
             'include_tags': include_tags,
             'include_extras': include_extras,
+            'include_translated': include_translated,
             'include_users': False,  # too slow - don't allow
             }
     if with_package_counts and 'dataset_counts' not in group_dictize_context:
@@ -79,6 +81,17 @@ def extras_dict_dictize(extras_dict, context):
     for name, extra in six.iteritems(extras_dict):
         dictized = d.table_dictize(extra, context)
         if not extra.state == 'active':
+            continue
+        value = dictized["value"]
+        result_list.append(dictized)
+
+    return sorted(result_list, key=lambda x: x["key"])
+
+def translated_dict_dictize(translated_dict, context):
+    result_list = []
+    for name, translated in six.iteritems(translated_dict):
+        dictized = d.table_dictize(translated, context)
+        if not translated.state == 'active' or '_translated' not in translated.key:
             continue
         value = dictized["value"]
         result_list.append(dictized)
@@ -279,6 +292,7 @@ def group_dictize(group, context,
                   include_tags=True,
                   include_users=True,
                   include_extras=True,
+                  include_translated=True,
                   packages_field='datasets',
                   **kw):
     '''
@@ -300,6 +314,14 @@ def group_dictize(group, context,
     if include_extras:
         result_dict['extras'] = extras_dict_dictize(
             group._extras, context)
+
+    if include_translated:
+        translated_dict = translated_dict_dictize(
+            group._extras, context)
+
+        for translated in translated_dict:
+            if translated['key'] not in result_dict:
+                result_dict[translated['key']] = translated['value']
 
     context['with_capacity'] = True
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -86,6 +86,18 @@ def extras_dict_dictize(extras_dict, context):
     return sorted(result_list, key=lambda x: x["key"])
 
 
+def translated_dict_dictize(translated_dict, context):
+    result_list = []
+    for name, translated in six.iteritems(translated_dict):
+        dictized = d.table_dictize(translated, context)
+        if not translated.state == 'active' or '_translated' not in translated.key:
+            continue
+        value = dictized["value"]
+        result_list.append(dictized)
+
+    return sorted(result_list, key=lambda x: x["key"])
+
+
 def extras_list_dictize(extras_list, context):
     result_list = []
     active = context.get('active', True)
@@ -301,6 +313,12 @@ def group_dictize(group, context,
     if include_extras:
         result_dict['extras'] = extras_dict_dictize(
             group._extras, context)
+
+    translated_fields = translated_dict_dictize(
+            group._extras, context)
+    for field in translated_fields:
+        if field['key'] not in result_dict:
+                result_dict[field['key']] = field['value']
 
     context['with_capacity'] = True
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -85,16 +85,6 @@ def extras_dict_dictize(extras_dict, context):
 
     return sorted(result_list, key=lambda x: x["key"])
 
-def translated_dict_dictize(translated_dict, context):
-    result_list = []
-    for name, translated in six.iteritems(translated_dict):
-        dictized = d.table_dictize(translated, context)
-        if not translated.state == 'active' or '_translated' not in translated.key:
-            continue
-        value = dictized["value"]
-        result_list.append(dictized)
-
-    return sorted(result_list, key=lambda x: x["key"])
 
 def extras_list_dictize(extras_list, context):
     result_list = []

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2833,13 +2833,18 @@ def license_options(existing_license_id=None):
 @core_helper
 def get_translated(data_dict, field):
     language = i18n.get_lang()
-    if hasattr( data_dict, '__dict__' ):
+    if hasattr(data_dict, '__dict__'):
         data_dict = data_dict.__dict__
     try:
         return data_dict[field + u'_translated'][language]
     except KeyError:
         val = data_dict.get(field, '')
+        if val is None:
+            val = ''
         return _(val) if val and isinstance(val, string_types) else val
+    except TypeError:
+        val = json.loads(data_dict[field + u'_translated'])
+        return val[language]
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2182,14 +2182,15 @@ def groups_available(am_member=False):
 
 @core_helper
 def organizations_available(
-        permission='manage_group', include_dataset_count=False):
+        permission='manage_group', include_dataset_count=False, include_translated=False):
     '''Return a list of organizations that the current user has the specified
     permission for.
     '''
     context = {'user': c.user}
     data_dict = {
         'permission': permission,
-        'include_dataset_count': include_dataset_count}
+        'include_dataset_count': include_dataset_count,
+        'include_translated': include_translated}
     return logic.get_action('organization_list_for_user')(context, data_dict)
 
 
@@ -2838,6 +2839,9 @@ def get_translated(data_dict, field):
     except KeyError:
         val = data_dict.get(field, '')
         return _(val) if val and isinstance(val, string_types) else val
+    except TypeError:
+        val = json.loads(data_dict[field + u'_translated'])
+        return val[language]
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2833,10 +2833,12 @@ def license_options(existing_license_id=None):
 @core_helper
 def get_translated(data_dict, field):
     language = i18n.get_lang()
+    if hasattr( data_dict, '__dict__' ):
+        data_dict = data_dict.__dict__
     try:
-        return data_dict.__dict__[field + u'_translated'][language]
+        return data_dict[field + u'_translated'][language]
     except KeyError:
-        val = data_dict.__dict__.get(field, '')
+        val = data_dict.get(field, '')
         return _(val) if val and isinstance(val, string_types) else val
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2834,9 +2834,9 @@ def license_options(existing_license_id=None):
 def get_translated(data_dict, field):
     language = i18n.get_lang()
     try:
-        return data_dict[field + u'_translated'][language]
+        return data_dict.__dict__[field + u'_translated'][language]
     except KeyError:
-        val = data_dict.get(field, '')
+        val = data_dict.__dict__.get(field, '')
         return _(val) if val and isinstance(val, string_types) else val
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2182,15 +2182,14 @@ def groups_available(am_member=False):
 
 @core_helper
 def organizations_available(
-        permission='manage_group', include_dataset_count=False, include_translated=False):
+        permission='manage_group', include_dataset_count=False):
     '''Return a list of organizations that the current user has the specified
     permission for.
     '''
     context = {'user': c.user}
     data_dict = {
         'permission': permission,
-        'include_dataset_count': include_dataset_count,
-        'include_translated': include_translated}
+        'include_dataset_count': include_dataset_count}
     return logic.get_action('organization_list_for_user')(context, data_dict)
 
 
@@ -2839,9 +2838,6 @@ def get_translated(data_dict, field):
     except KeyError:
         val = data_dict.get(field, '')
         return _(val) if val and isinstance(val, string_types) else val
-    except TypeError:
-        val = json.loads(data_dict[field + u'_translated'])
-        return val[language]
 
 
 @core_helper

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -727,9 +727,13 @@ def organization_list_for_user(context, data_dict):
 
     context['with_capacity'] = True
     orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
-        with_package_counts=asbool(data_dict.get('include_dataset_count')),
-        include_translated=asbool(data_dict.get('include_translated')))
-    return orgs_list
+        with_package_counts=asbool(data_dict.get('include_dataset_count')))
+    return_list = []
+    for org in orgs_list:
+        return_list.append(logic.get_action('organization_show')(
+                                context,
+                                {'id': org['id']}))
+    return return_list
 
 
 def license_list(context, data_dict):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -726,13 +726,12 @@ def organization_list_for_user(context, data_dict):
             (org, group_ids_to_capacities[org.id]) for org in orgs_q.all()]
 
     context['with_capacity'] = True
-    orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
-        with_package_counts=asbool(data_dict.get('include_dataset_count')))
     return_list = []
-    for org in orgs_list:
+    for org, cap in orgs_and_capacities:
         return_list.append(logic.get_action('organization_show')(
                                 context,
-                                {'id': org['id']}))
+                                {'id': org.id,
+                                'include_dataset_count': asbool(data_dict.get('include_dataset_count'))}))
     return return_list
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -726,18 +726,9 @@ def organization_list_for_user(context, data_dict):
             (org, group_ids_to_capacities[org.id]) for org in orgs_q.all()]
 
     context['with_capacity'] = True
-    return_list = []
-    for org, cap in orgs_and_capacities:
-        return_list.append(logic.get_action('organization_show')(
-                                context,
-                                {'id': org.id,
-                                'include_dataset_count': False,
-                                'include_datasets': False,
-                                'include_tags': False,
-                                'include_users': False,
-                                'include_groups': False,
-                                'include_followers': False}))
-    return return_list
+    orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
+        with_package_counts=asbool(data_dict.get('include_dataset_count')))
+    return orgs_list
 
 
 def license_list(context, data_dict):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -727,7 +727,8 @@ def organization_list_for_user(context, data_dict):
 
     context['with_capacity'] = True
     orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
-        with_package_counts=asbool(data_dict.get('include_dataset_count')))
+        with_package_counts=asbool(data_dict.get('include_dataset_count')),
+        include_translated=asbool(data_dict.get('include_translated')))
     return orgs_list
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -731,7 +731,12 @@ def organization_list_for_user(context, data_dict):
         return_list.append(logic.get_action('organization_show')(
                                 context,
                                 {'id': org.id,
-                                'include_dataset_count': asbool(data_dict.get('include_dataset_count'))}))
+                                'include_dataset_count': False,
+                                'include_datasets': False,
+                                'include_tags': False,
+                                'include_users': False,
+                                'include_groups': False,
+                                'include_followers': False}))
     return return_list
 
 


### PR DESCRIPTION
… and dictization.

Adds `include_translated` to the available orgs helper and dictizations. It will merge in the extras which contain `_translated` in their keys into the returned dict. This is done to allow usage with the `get_translated` helper.

I had to add `TypeError` exception handling to the `get_translated` helper so json load the values.