### PR TITLE
Modified the default `sort_key` callable for `group_list_dictize` to …

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -531,7 +531,7 @@ def tag_dictize(tag, context, include_datasets=True):
     return tag_dict
 
 def user_list_dictize(obj_list, context,
-                      sort_key=lambda x:x['name'], reverse=False):
+                      sort_key=lambda x: x['name'].lower(), reverse=False):
 
     result_list = []
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -28,7 +28,7 @@ import ckan.lib.munge as munge
 ## package save
 
 def group_list_dictize(obj_list, context,
-                       sort_key=lambda x: x['display_name'], reverse=False,
+                       sort_key=lambda x: x['display_name'].lower(), reverse=False,
                        with_package_counts=True,
                        include_groups=False,
                        include_tags=False,

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -28,7 +28,7 @@ import ckan.lib.munge as munge
 ## package save
 
 def group_list_dictize(obj_list, context,
-                       sort_key=lambda x: x['display_name'].lower(), reverse=False,
+                       sort_key=lambda x: h.strxfrm(x['display_name']), reverse=False,
                        with_package_counts=True,
                        include_groups=False,
                        include_tags=False,
@@ -531,7 +531,7 @@ def tag_dictize(tag, context, include_datasets=True):
     return tag_dict
 
 def user_list_dictize(obj_list, context,
-                      sort_key=lambda x: x['name'].lower(), reverse=False):
+                      sort_key=lambda x: h.strxfrm(x['name']), reverse=False):
 
     result_list = []
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -18,6 +18,7 @@ import copy
 import urlparse
 from urllib import urlencode
 import uuid
+import unicodedata
 
 from paste.deploy import converters
 from webhelpers.html import HTML, literal, tags, tools
@@ -596,6 +597,16 @@ def current_url():
 def lang():
     ''' Return the language code for the current locale eg `en` '''
     return request.environ.get('CKAN_LANG')
+
+
+@core_helper
+def strxfrm(s):
+    # type: (str) -> str
+    '''
+    Transform a string to one that can be used in locale-aware comparisons.
+    Override this helper if you have different text sorting needs.
+    '''
+    return unicodedata.normalize('NFD', s).lower()
 
 
 @core_helper


### PR DESCRIPTION
…not be ASCIIbetical, matching the sorting coming from the db queries elsewhere.

Fixes #

Used `lower()` call in the `sort_key` default callable in `group_list_dictize`. Python sort/sorted is ASCIIbetical, whereas the db queries are purely alphabetical. This change makes sure that the `group_list_dictize` sorting matches the db query sorting.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
