### PR TITLE
display label from data dictionary (when available) for a field in datatablesview

### DIFF
--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -29,7 +29,11 @@
             {{ 'checked' if 'show_fields' not in data else
               'checked' if f.id in data.show_fields else '' }}
             />{{ f.id }}</label></td>
-          <td>{{ f.get('info', {}).label }}</td>
+          <td>
+            {%- block dict_field_label scoped -%}
+              {{ f.get('info', {}).label }}
+            {%- endblock -%}
+          </td>
         </tr>
       {% endfor %}
     </table>

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -42,7 +42,7 @@
             or field.id in resource_view.show_fields %}
             <th scope="col">
               {% set label = 'label_' + h.lang() %}
-              {% if label in field.info and field.info[label]|length %}
+              {% if label in field.info and field.info[label] %}
                 {{ field.info[label] }}
               {% else %}
                 {{ field.id }}

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -41,12 +41,13 @@
           {% if 'show_fields' not in resource_view
             or field.id in resource_view.show_fields %}
             <th scope="col">
-              {% set label = 'label_' + h.lang() %}
-              {% if label in field.info and field.info[label] %}
-                {{ field.info[label] }}
-              {% else %}
-                {{ field.id }}
-              {% endif %}
+              {%- block datatable_column_label scoped -%}
+                {%- if 'label' in field.info and field.info.label -%}
+                  {{ field.info.label }}
+                {%- else -%}
+                  {{ field.id }}
+                {%- endif -%}
+              {%- endblock -%}
             </th>
           {% endif %}
         {% endfor %}

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -40,7 +40,14 @@
         {% for field in [{'id': '_id'}] + h.datastore_dictionary(resource.id) %}
           {% if 'show_fields' not in resource_view
             or field.id in resource_view.show_fields %}
-            <th scope="col">{{ field.id }}</th>
+            <th scope="col">
+              {% set label = 'label_' + h.lang() %}
+              {% if label in field.info and field.info[label]|length %}
+                {{ field.info[label] }}
+              {% else %}
+                {{ field.id }}
+              {% endif %}
+            </th>
           {% endif %}
         {% endfor %}
       </tr>


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:
Display labels for columns in datatablesview if user sets labels in data dictionary for a resource. Default to `field.id` if no label is set for a field in the data dictionary for the resource.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
