### PR TITLE
Added catch for resource default view creations.

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -336,14 +336,21 @@ def resource_create(context, data_dict):
     resource = updated_pkg_dict['resources'][-1]
 
     #  Add the default views to the new resource
-    logic.get_action('resource_create_default_resource_views')(
-        {'model': context['model'],
-         'user': context['user'],
-         'ignore_auth': True
-         },
-        {'resource': resource,
-         'package': updated_pkg_dict
-         })
+    try:
+        logic.get_action('resource_create_default_resource_views')(
+            {'model': context['model'],
+            'user': context['user'],
+            'ignore_auth': True
+            },
+            {'resource': resource,
+            'package': updated_pkg_dict
+            })
+    except ValidationError as e:
+        if e.error_dict is not None:
+            log.debug('resource_create_default_resource_views validate_errs=%r user=%s package=%s data=%r',
+                e.error_dict, context['user'],
+                pkg_dict['name'] if pkg_dict else '',
+                resource)
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_create(context, resource)


### PR DESCRIPTION
Strangely, no ValidationErrors were being thrown during the `plugin_validate` on the action `package_update` during the `resource_create` action. However, the ValidationError was being thrown during the `resource_create_default_resource_views` action.

I am not too sure why it would get thrown in the `resource_create_default_resource_views` action, perhaps that action runs the validation again? Which does not entirely seems great as the validation for the dataset and resources just ran?

For now I just put it in a try/catch and put a debug log with the info.

I am not even sure if we would want to fully stop a package or resource from being created if their default views cannot be created?