### PR TITLE
Added `title_fr` and `description_fr` dict keys for default resource …

### DIFF
--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -261,12 +261,16 @@ def add_views_to_resource(context,
             'resource': resource_dict,
             'package': dataset_dict
                 }):  # noqa
+
+            # `title` and `description` are removed from this dict,
+            # and is set via default schema values in:
+            # `https://github.com/open-data/ckanext-canada/blob/master/ckanext/canada/plugins.py`
+            # `resource_view_create_bilingual`
+            # This is done to correct issues with default view creation
+            # with the Open Data Canada English/French requirements.
+            #                                           Oct 17 2022
             view = {'resource_id': resource_dict['id'],
-                    'view_type': view_info['name'],
-                    'title': view_info.get('default_title', _('View')),
-                    'title_fr': view_info.get('default_title', _('View')),
-                    'description': view_info.get('default_description', ''),
-                    'description_fr': view_info.get('default_description', '')}
+                    'view_type': view_info['name']}
 
             view_dict = p.toolkit.get_action('resource_view_create')(context,
                                                                      view)

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -264,7 +264,9 @@ def add_views_to_resource(context,
             view = {'resource_id': resource_dict['id'],
                     'view_type': view_info['name'],
                     'title': view_info.get('default_title', _('View')),
-                    'description': view_info.get('default_description', '')}
+                    'title_fr': view_info.get('default_title', _('View')),
+                    'description': view_info.get('default_description', ''),
+                    'description_fr': view_info.get('default_description', '')}
 
             view_dict = p.toolkit.get_action('resource_view_create')(context,
                                                                      view)


### PR DESCRIPTION
Schema failed for default resource view creations due to `title_fr` and `description_fr` not being passed during the default view creation. These were only passed view the webform submissions.

Although we personally do not use default views, this fix should allow us to easily use them in the future if we want to.