### PR TITLE
Request Password Reset with Email Address

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -485,17 +485,21 @@ class UserController(base.BaseController):
                 except NotFound:
                     pass
             else:
-                user_list = logic.get_action(u'user_list')(context, {
-                    u'email': id
-                })
+                # we do a query here because ckanext-canada disables
+                # the user-list action for non-logged in users
+                user_list = []
+                query = model.Session.query(model.User.name)
+                query = query.filter_by(email=id)
+                for user in query.all():
+                    user_list.append(user[0])
                 if user_list:
                     # send reset emails for *all* user accounts with this email
                     # (otherwise we'd have to silently fail - we can't tell the
                     # user, as that would reveal the existence of accounts with
                     # this email address)
-                    for user_dict in user_list:
+                    for username in user_list:
                         logic.get_action(u'user_show')(
-                            context, {u'id': user_dict[u'id']})
+                            context, {u'id': username})
                         user_objs.append(context[u'user_obj'])
 
             if not user_objs:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -525,19 +525,23 @@ class RequestResetView(MethodView):
             # Search by email address
             # (You can forget a user id, but you don't tend to forget your
             # email)
-            user_list = logic.get_action(u'user_list')(context, {
-                u'email': id
-            })
+            # we do a query here because ckanext-canada disables
+            # the user-list action for non-logged in users
+            user_list = []
+            query = model.Session.query(model.User.name)
+            query = query.filter_by(email=id)
+            for user in query.all():
+                user_list.append(user[0])
             if user_list:
                 # send reset emails for *all* user accounts with this email
                 # (otherwise we'd have to silently fail - we can't tell the
                 # user, as that would reveal the existence of accounts with
                 # this email address)
-                for user_dict in user_list:
+                for username in user_list:
                     # This is ugly, but we need the user object for the mailer,
                     # and user_list does not return them
                     logic.get_action(u'user_show')(
-                        context, {u'id': user_dict[u'id']})
+                        context, {u'id': username})
                     user_objs.append(context[u'user_obj'])
 
         else:


### PR DESCRIPTION
Replaced `user_list` action call with a direct query call due to `ckanext-canada` disabling the `user_list` action for non-authenticated users.

Users should be able to request a password reset with their email. The flash error message for the reset form even states that "Email is required". Although that our form label says "username", we should probably allow for the users to input their email as intended in the code?

According to the code, it SHOULD allow you to do it. However in https://github.com/open-data/ckanext-canada/blob/master/ckanext/canada/plugins.py#L515, the `user_list` action is disabled for non-authenticated users. And the password reset uses the `user_list` action to lookup users by email address (https://github.com/open-data/ckan/blob/canada-v2.8/ckan/views/user.py#L528)

So instead of using the `user_list` action, I have replaced it with a direct query on the User model.