### PR TITLE
Cherry Pick Upstream PR for Datatables View Special Characters Encoding/Decoding

### DIFF
--- a/changes/6747.misc
+++ b/changes/6747.misc
@@ -1,0 +1,7 @@
+Reworked the JavaScript for the view filters to allow for special characters as well as colons and pipes, which previously caused errors. Added a new helper to easily decode the new flattened filter string.
+
+- New helper `decode_view_request_filters`
+    - Returns a `dictionary` of the decoded filter names and their values in a `list`.
+- View Filters JS related code will now encode the filter names and values before flattening into a colon (`:`) and piped (`|`) string.   
+    - Allowing for colons and pipes to be in the filter names and values.
+    - Allowing special characters to be in the filter names and values (such as accented chars). 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -3004,3 +3004,47 @@ def can_update_owner_org(package_dict, user_orgs=None):
         return True
 
     return False
+
+
+@core_helper
+def decode_view_request_filters():
+    filterString = request.args.get('filters')
+    if request.form.get('filters') is not None:
+        filterString = request.form.get('filters')
+    if filterString is not None and len(filterString) > 0:
+        filters = {}
+        for k_v in filterString.split(u'|'):
+            k, _sep, v = k_v.partition(u':')
+            if unquote(str(k)) in filters:
+                if unquote(str(v)) not in filters[unquote(str(k))]:
+                    filters[unquote(str(k))].append(unquote(str(v)))
+            else:
+                filters.setdefault(unquote(str(k)), []).append(unquote(str(v)))
+        return filters
+    return None
+
+
+@core_helper
+def check_ckan_version(min_version,
+                       max_version):
+    """Return ``True`` if the CKAN version is greater than or equal to
+    ``min_version`` and less than or equal to ``max_version``,
+    return ``False`` otherwise.
+
+    If no ``min_version`` is given, just check whether the CKAN version is
+    less than or equal to ``max_version``.
+
+    If no ``max_version`` is given, just check whether the CKAN version is
+    greater than or equal to ``min_version``.
+
+    :param min_version: the minimum acceptable CKAN version,
+        eg. ``'2.1'``
+    :type min_version: string
+
+    :param max_version: the maximum acceptable CKAN version,
+        eg. ``'2.3'``
+    :type max_version: string
+
+    """
+    return p.toolkit.check_ckan_version(min_version=min_version,
+                                        max_version=max_version)

--- a/ckan/public/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public/base/javascript/modules/resource-view-filters.js
@@ -156,9 +156,10 @@ this.ckan.module('resource-view-filters', function (jQuery) {
     currentFilters = currentFilters.slice();
 
     if (evt.removed) {
-      addToIndex = currentFilters.indexOf(evt.removed.id);
       if (addToIndex !== -1) {
-        currentFilters.splice(addToIndex, 1);
+        if( typeof evt.removed.id !== "undefined" && currentFilters.indexOf(evt.removed.id) !== -1 ){
+          currentFilters.splice(currentFilters.indexOf(evt.removed.id), 1);
+        }
       }
     }
     if (evt.added) {

--- a/ckan/public/base/javascript/view-filters.js
+++ b/ckan/public/base/javascript/view-filters.js
@@ -17,6 +17,17 @@ this.ckan.views.filters = (function (queryString) {
   function get(filterName) {
     var filters = api._searchParams.filters || {};
 
+    if( ! $.isEmptyObject(filters) ){
+      let decodedFilters = {};
+      $.each(filters, function(_filterIndex,_filter){
+        decodedFilters[decodeURIComponent(_filterIndex)] = [];
+        $.each(_filter, function(_valueIndex,_filterValue){
+          decodedFilters[decodeURIComponent(_filterIndex)][_valueIndex] = decodeURIComponent(_filterValue); 
+        });
+      });
+      filters = decodedFilters;
+    }
+
     if (filterName) {
       return filters[filterName];
     } else {
@@ -92,7 +103,7 @@ this.ckan.views.filters = (function (queryString) {
         }
         // Encode ':' and '|' as '#:' and '#|' to avoid conflicts when splitting filters.
         var fieldsStr = $.map(fields, function (field) {
-          return filter.replace(/(?<!#):/g, '#:') + ':' + field.replace(/(?<!#)\|/g, '#|').replace(/(?<!#):/g, '#:');
+          return encodeURIComponent(filter) + ':' + encodeURIComponent(field);
         });
 
         return fieldsStr.join('|');
@@ -138,8 +149,8 @@ this.ckan.views.filters = (function (queryString) {
             field = fieldValue[1],
             value = fieldValue[2];
 
-        filters[field] = filters[field] || [];
-        filters[field].push(value);
+        filters[decodeURIComponent(field)] = filters[decodeURIComponent(field)] || [];
+        filters[decodeURIComponent(field)].push(decodeURIComponent(value));
       }
 
       searchParams.filters = filters;

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -16,7 +16,6 @@ import ckan.exceptions
 from ckan.tests import helpers
 import ckan.lib.base as base
 
-
 CkanUrlException = ckan.exceptions.CkanUrlException
 
 
@@ -876,3 +875,15 @@ def test_sanitize_url():
             u'http://éxàmple.com/some:path/to+a/fil[e].jpg'
         )
     ) == h.sanitize_url(u'http://éxàmple.com/some:path/to+a/fil[e].jpg')
+
+
+@pytest.mark.usefixtures("with_request_context")
+def test_decode_view_request_filters(test_request_context):
+
+    with test_request_context(u'?filters=Titl%25C3%25A8:T%25C3%25A9st|Dat%25C3%25AA%2520Time:2022-01-01%252001%253A01%253A01|_id:1|_id:2|_id:3|Piped%257CFilter:Piped%257CValue'):
+        assert h.decode_view_request_filters() == {
+            'Titlè': ['Tést'],
+            'Datê Time': ['2022-01-01 01:01:01'],
+            '_id': ['1', '2', '3'],
+            'Piped|Filter': ['Piped|Value']
+        }


### PR DESCRIPTION
Merge branch 'feature/datatablesview-filters-special-chars' of https://github.com/JVickery-TBS/ckan into JVickery-TBS-feature/datatablesview-filters-special-chars

# Conflicts:
#	ckan/lib/helpers.py
#	ckan/public/base/javascript/view-filters.js
#	ckan/tests/lib/test_helpers.py
#	ckanext/datatablesview/blueprint.py
### RESOLVED.