### PR TITLE
Resttrict Manage Resource in Archive Viewing

### DIFF
--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -43,7 +43,7 @@
 
   {% block package_resources %}
     {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources,
-      can_edit=h.check_access('package_update', {'id':pkg.id }) %}
+      can_edit=h.check_access('package_update', {'id':pkg.id }), is_activity_archive=is_activity_archive %}
   {% endblock %}
 
   {% block package_tags %}

--- a/ckan/templates/package/resources.html
+++ b/ckan/templates/package/resources.html
@@ -12,7 +12,7 @@
     <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
       {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
       {% for resource in pkg.resources %}
-        {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=true, can_edit=can_edit, is_activity_archive=False %}
+        {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=true, can_edit=can_edit, is_activity_archive=is_activity_archive %}
       {% endfor %}
     </ul>
   {% else %}

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -24,12 +24,12 @@ Example:
         {% block resources_list %}
           <ul class="list-unstyled nav nav-simple">
             {% for resource in resources %}
-              {% set url = h.url_for('%s_resource.read' % pkg.type, id=pkg.name, resource_id=resource.id) %}
+              {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.id if is_activity_archive else pkg.name, resource_id=resource.id, **({'activity_id': request.args['activity_id']} if 'activity_id' in request.args else {})) %}
               {% if active == resource.id %}
                 <li class="nav-item active">
                   <a href="#">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                 </li>
-              {% elif can_edit %}
+              {% elif can_edit and not is_activity_archive %}
                 <li class="nav-item d-flex justify-content-between position-relative">
                   <a class="flex-fill" href="{{ url }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                   <div class="dropdown position-absolute end-0 me-2">
@@ -54,7 +54,7 @@ Example:
   {% endblock %}
 {% endif %}
 
-{% if can_edit %}
+{% if can_edit and not is_activity_archive %}
   <div class="module-content">
     {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-light btn-sm', icon='plus' %}
   </div>


### PR DESCRIPTION
feat(templates): prevent resource manage in archive view;

- Do not render manage action links while viewing resource archives.
