### PR TITLE
WET/BS Danger Alerts, and Multiple User Password Reset Validation Messages

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -734,7 +734,7 @@ class Message(object):
 class _Flash(object):
 
     # List of allowed categories.  If None, allow any category.
-    categories = ["", "alert-info", "alert-error", "alert-success"]
+    categories = ["", "alert-info", "alert-danger", "alert-success"]
 
     # Default category if none is specified.
     default_category = ""
@@ -797,7 +797,7 @@ def flash_notice(message, allow_html=False):
 @core_helper
 def flash_error(message, allow_html=False):
     ''' Show a flash message of type error '''
-    flash(message, category='alert-error', allow_html=allow_html)
+    flash(message, category='alert-danger', allow_html=allow_html)
 
 
 @core_helper
@@ -3038,7 +3038,7 @@ def can_update_owner_org(package_dict, user_orgs=None):
 
     return False
 
-  
+
 @core_helper
 def decode_view_request_filters():
     filterString = request.args.get('filters')

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -776,7 +776,11 @@ class PerformResetView(MethodView):
         except dictization_functions.DataError:
             h.flash_error(_(u'Integrity Error'))
         except logic.ValidationError as e:
-            h.flash_error(u'%r' % e.error_dict)
+            # only print the error messages into separate flash messages.
+            # (canada fork only)
+            for _k, err_messages in e.error_dict.items():
+                for err_message in err_messages:
+                    h.flash_error('{message}'.format(message=_(err_message)))
         except ValueError as e:
             h.flash_error(text_type(e))
         user_dict[u'state'] = user_state

--- a/ckanext/datapusher/templates-bs2/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates-bs2/datapusher/resource_data.html
@@ -15,11 +15,11 @@
 
   {% if status.error and status.error.message %}
     {% set show_table = false %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
       <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
     </div>
   {% elif status.task_info and status.task_info.error %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
       {% if status.task_info.error is string %}
         {# DataPusher < 0.0.3 #}
         <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -15,11 +15,11 @@
 
   {% if status.error and status.error.message %}
     {% set show_table = false %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
       <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
     </div>
   {% elif status.task_info and status.task_info.error %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
       {% if status.task_info.error is string %}
         {# DataPusher < 0.0.3 #}
         <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}


### PR DESCRIPTION
fix(templates): bs alerts, user reset view;

- Fixed output of multiple validation errors for user reset password form.
- Changed `alert-error` to `alert-danger` for wet/bs.