### PR TITLE
Delete Activities Command

### DIFF
--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -43,6 +43,38 @@ PROMPT_MSG = u'This will delete all of your data!\nDo you want to continue?'
 
 
 @db.command()
+@click.option(
+    u"-d",
+    u"--days",
+    help=u"Number of days to go back. E.g. 120 will keep 120 days of activities. Default: 90",
+    default=90
+)
+@click.option(u"-q", u"--quiet", is_flag=True, help=u"Supress human input.", default=False)
+def delete_activities(days=90, quiet=False):
+    """Delete rows from the activity table past a certain number of days.
+    """
+    activity_count = model.Session.execute(
+                        u"SELECT count(*) FROM activity "
+                        "WHERE timestamp < NOW() - INTERVAL '{d} days';"
+                        .format(d=days)) \
+                        .fetchall()[0][0]
+
+    if not bool(activity_count):
+        click.echo(u"\nNo activities found past {d} days".format(d=days))
+        return
+
+    if not quiet:
+        click.confirm(u"\nAre you sure you want to delete {num} activities?"
+                          .format(num=activity_count), abort=True)
+
+    model.Session.execute(u"DELETE FROM activity WHERE timestamp < NOW() - INTERVAL '{d} days';"
+                          .format(d=days))
+    model.Session.commit()
+
+    click.echo(u"\nDeleted {num} rows from the activity table".format(num=activity_count))
+
+
+@db.command()
 @click.confirmation_option(prompt=PROMPT_MSG)
 def clean():
     """Clean the database.


### PR DESCRIPTION
feat(cli): added delete activities sub command;

- Added `delete-activites` sub command.

@wardi I put the `delete-activities` sub-command in the `db` command instead of the `dataset` command as the activities are used for other things right (not just datasets and resources)? Or at least they will be in the future or in 2.10. And of course in upstream, activities are now in its own extension, so this command will be added there