### PR TITLE
Optimize Extra Logging

### DIFF
--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -296,9 +296,10 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         context[u'user'] = None
         context[u'auth_user_obj'] = None
 
-    # return the context and request_data for extra logging (canada fork only)
+    # return the context, request_data, and return_dict
+    # for Recombinant access and extra logging (canada fork only)
     if ver == -1:
-        return context, request_data
+        return context, request_data, return_dict
 
     # Call the action function, catch any exception
     try:

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -296,6 +296,10 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         context[u'user'] = None
         context[u'auth_user_obj'] = None
 
+    # return the context and request_data for extra logging (canada fork only)
+    if ver == -1:
+        return context, request_data
+
     # Call the action function, catch any exception
     try:
         result = function(context, request_data)


### PR DESCRIPTION
Instead of repeating all the code in our extension, just adds a little piece here to return what we need for Extra Logging and Recombinant API access.

And because the Flask route is specific to version `1-3` (or no version), a user cannot actually access this route at `-1`. That is only achievable if you call the method directly, supplying `-1` for the `ver`.