### PR TITLE
Dynamic Load w/ Delay for Data Viewer Module (Resource Views)

### DIFF
--- a/ckan/public/base/javascript/modules/data-viewer.js
+++ b/ckan/public/base/javascript/modules/data-viewer.js
@@ -5,7 +5,9 @@ this.ckan.module('data-viewer', function (jQuery) {
     options: {
       timeout: 200,
       minHeight: 400,
-      padding: 30
+      padding: 30,
+      delay: 0,
+      framesource: '',
     },
 
     initialize: function () {
@@ -13,6 +15,16 @@ this.ckan.module('data-viewer', function (jQuery) {
       this.el.on('load', this._onLoad);
       this._FirefoxFix();
       this.sandbox.subscribe('data-viewer-error', this._onDataViewerError);
+      // dynamically set the iFrame source
+      // TODO: upstream contribution??
+      let delay = this.options.delay;
+      let framesource = this.options.framesource;
+      let element = this.el;
+      if( framesource.length > 0 ){
+        setTimeout(function(){
+          $(element).attr('src', framesource);
+        }, delay);
+      }
     },
 
     _onDataViewerError: function(message) {

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -60,7 +60,8 @@
           {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
           {% set src = h.url_for(package['type'] ~ '_resource.view', id=package['name'], resource_id=resource['id'], qualified=true) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
         {% endif %}
-        <iframe src="{{ src }}" frameborder="0" width="100%" data-module="data-viewer" aria-label="{{ _('Preview') }}">
+        {# add lazy loading via data-viewer module (canada fork only) TODO: upstream contribution?? #}
+        <iframe src="" data-module-framesource="{{ src }}" data-module-delay="1500" loading="lazy" frameborder="0" width="100%" data-module="data-viewer" aria-label="{{ _('Preview') }}">
           <p>{{ _('Your browser does not support iframes.') }}</p>
         </iframe>
       {% endif %}


### PR DESCRIPTION
feat(modules): adds dynamic source delay to iframes for data viewer;

- Add iFrame source load delay.

@wardi as discussed, the lazy load does not work when the iframe is at top of viewport as the viewport api is available well before the page loads. So I have expanded the CKAN `data-viewer` module to accept a frame source and delay attribute. And then use these to set the iFrame's `src` attribute after that delay.

From testing on a medium sized DataStore resource with a DataTable view, it saved `0.08` to `0.11` seconds of load time. Which is fairly significant. (EDIT: messed up stats because I don't know how to read milliseconds apparently)