### PR TITLE
Job List Limit & Offset

### DIFF
--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -40,13 +40,18 @@ def worker(burst, queues):
 
 
 @jobs.command(name=u"list", short_help=u"List jobs.")
+@click.option(u"-l", u"--limit",
+              help=u"Number of jobs to return. Default: %s" %
+                bg_jobs.DEFAULT_JOB_LIST_LIMIT,
+              default=bg_jobs.DEFAULT_JOB_LIST_LIMIT)
 @click.argument(u"queues", nargs=-1)
-def list_jobs(queues):
+def list_jobs(queues, limit=bg_jobs.DEFAULT_JOB_LIST_LIMIT):
     """List currently enqueued jobs from the given queues. If no queue
     names are given then the jobs from all queues are listed.
     """
     data_dict = {
         u"queues": list(queues),
+        u"limit": limit,
     }
     jobs = p.toolkit.get_action(u"job_list")({u"ignore_auth": True}, data_dict)
     if not jobs:

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -44,24 +44,30 @@ def worker(burst, queues):
               help=u"Number of jobs to return. Default: %s" %
                 bg_jobs.DEFAULT_JOB_LIST_LIMIT,
               default=bg_jobs.DEFAULT_JOB_LIST_LIMIT)
+@click.option(u"-i", u"--ids", is_flag=True,
+              help=u"Only return a list of job ids.", default=False)
 @click.argument(u"queues", nargs=-1)
-def list_jobs(queues, limit=bg_jobs.DEFAULT_JOB_LIST_LIMIT):
+def list_jobs(queues, limit=bg_jobs.DEFAULT_JOB_LIST_LIMIT, ids=False):
     """List currently enqueued jobs from the given queues. If no queue
     names are given then the jobs from all queues are listed.
     """
     data_dict = {
         u"queues": list(queues),
         u"limit": limit,
+        u"ids_only": ids,
     }
     jobs = p.toolkit.get_action(u"job_list")({u"ignore_auth": True}, data_dict)
     if not jobs:
         return click.secho(u"There are no pending jobs.", fg=u"green")
     for job in jobs:
-        if job[u"title"] is None:
-            job[u"title"] = u""
+        if ids:
+            click.secho(job)
         else:
-            job[u"title"] = u'"{}"'.format(job[u"title"])
-        click.secho(u"{created} {id} {queue} {title}".format(**job))
+            if job[u"title"] is None:
+                job[u"title"] = u""
+            else:
+                job[u"title"] = u'"{}"'.format(job[u"title"])
+            click.secho(u"{created} {id} {queue} {title}".format(**job))
 
 
 @jobs.command(short_help=u"Show details about a specific job.")

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -38,6 +38,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
 DEFAULT_JOB_TIMEOUT = 180
+DEFAULT_JOB_LIST_LIMIT = 200
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3558,10 +3558,10 @@ def job_list(context, data_dict):
         queues = jobs.get_all_queues()
     for queue in queues:
         if ids_only:
-            jobs_list += queue.job_ids
+            jobs_list += queue.job_ids[:limit]
         else:
-            jobs_list += [jobs.dictize_job(j) for j in queue.jobs]
-    return jobs_list[:limit]
+            jobs_list += [jobs.dictize_job(j) for j in queue.jobs[:limit]]
+    return jobs_list
 
 
 def job_show(context, data_dict):

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -790,9 +790,10 @@ def update_configuration_schema():
 
 
 @validator_args
-def job_list_schema(ignore_missing, list_of_strings):
+def job_list_schema(ignore_missing, list_of_strings, int_validator):
     return {
         u'queues': [ignore_missing, list_of_strings],
+        u'limit': [ignore_missing, int_validator],
     }
 
 

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -790,10 +790,12 @@ def update_configuration_schema():
 
 
 @validator_args
-def job_list_schema(ignore_missing, list_of_strings, int_validator):
+def job_list_schema(ignore_missing, list_of_strings,
+                    int_validator, boolean_validator):
     return {
         u'queues': [ignore_missing, list_of_strings],
         u'limit': [ignore_missing, int_validator],
+        u'ids_only': [ignore_missing, boolean_validator],
     }
 
 


### PR DESCRIPTION
feat(logic): limit and offset for job list;

- Added params to `job_list` logic action method.

@wardi seems like there is kind of an issue with how to limit/offset the job lists here, because of the case of multiple queue. It is fine for us of course because we only use on Redis queue. But when putting this upstream, I am not sure how to get around that :/