### PR TITLE
Datastore Records Delete Action Fix

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -522,7 +522,7 @@ def datastore_records_delete(context, data_dict):
         raise p.toolkit.ValidationError(errors)
     # (canada fork only): need to call auth check in < upstream:2.10|master
     p.toolkit.check_access('datastore_records_delete', context, data_dict)
-    return datastore_delete(context, data_dict)
+    return p.toolkit.get_action('datastore_delete')(context, data_dict)
 
 
 @logic.side_effect_free


### PR DESCRIPTION
fix(logic): ds delete;

- Call `datastore_delete` action via toolkit in `datastore_records_delete`.

Related: https://github.com/ckan/ckanext-dsaudit/pull/2