### PR TITLE
Exclude _id from DataStore Dump View

### DIFF
--- a/changes/175.canada.changes
+++ b/changes/175.canada.changes
@@ -1,0 +1,1 @@
+DataStore Dump endpoint no longer includes the _id field/column.

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -57,7 +57,7 @@ def exclude_id_from_ds_dump(key, data, errors, context):
     value = data.get(key)
 
     if not has_request_context() and not hasattr(request, 'view_args') and 'resource_id' not in request.view_args:
-        # treat as ignore_missing
+        # treat as ignore, as outside of Blueprint/Request context.
         data.pop(key, None)
         raise StopOnError
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -71,7 +71,7 @@ def exclude_id_from_ds_dump(key, data, errors, context):
         # fields accepts string or list of strings
         if isinstance(value, text_type):
             value = value.split(',')
-        if isinstance(value, list):
+        if isinstance(value, list) and '_id' in value:
             value.remove('_id')
 
     data[key] = value

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -65,10 +65,8 @@ def exclude_id_from_ds_dump(key, data, errors, context):
 
     if value is missing or value is None:
         ds_info = get_action('datastore_info')(context, {'id': resource_id})
-        value = []
         # _id is never returned from datastore_info
-        for field in ds_info.get('fields', []):
-            value.append(field.get('id'))
+        value = [field['id'] for field in ds_info.get('fields', [])]
     else:
         # fields accepts string or list of strings
         if isinstance(value, text_type):

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -44,6 +44,40 @@ PAGINATE_BY = 32000
 
 datastore = Blueprint(u'datastore', __name__)
 
+# (canada fork only): exclude _id field from Blueprint dump
+from ckan.plugins.toolkit import missing, StopOnError
+from flask import has_request_context
+from six import text_type
+def exclude_id_from_ds_dump(key, data, errors, context):
+    """
+    Always set the list of fields to dump from the DataStore. Excluding to _id column.
+
+    This validator is only used in the dump_schema.
+    """
+    value = data.get(key)
+
+    if not has_request_context() and not hasattr(request, 'view_args') and 'resource_id' not in request.view_args:
+        # treat as ignore_missing
+        data.pop(key, None)
+        raise StopOnError
+
+    resource_id = request.view_args['resource_id']
+    ds_info = get_action('datastore_info')(context, {'id': resource_id})
+
+    if value is missing or value is None:
+        value = []
+        # _id is never returned from datastore_info
+        for field in ds_info.get('fields', []):
+            value.append(field.get('id'))
+    else:
+        # fields accepts string or list of strings
+        if isinstance(value, text_type):
+            value = value.split(',')
+        if isinstance(value, list):
+            value.remove('_id')
+
+    data[key] = value
+
 
 def dump_schema():
     return {
@@ -56,7 +90,7 @@ def dump_schema():
         u'distinct': [ignore_missing, boolean_validator],
         u'plain': [ignore_missing, boolean_validator],
         u'language': [ignore_missing, unicode_only],
-        u'fields': [ignore_missing, list_of_strings_or_string],
+        u'fields': [exclude_id_from_ds_dump, list_of_strings_or_string],  # (canada fork only): exclude _id field from Blueprint dump
         u'sort': [default(u'_id'), list_of_strings_or_string],
     }
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -62,9 +62,9 @@ def exclude_id_from_ds_dump(key, data, errors, context):
         raise StopOnError
 
     resource_id = request.view_args['resource_id']
-    ds_info = get_action('datastore_info')(context, {'id': resource_id})
 
     if value is missing or value is None:
+        ds_info = get_action('datastore_info')(context, {'id': resource_id})
         value = []
         # _id is never returned from datastore_info
         for field in ds_info.get('fields', []):


### PR DESCRIPTION
feat(views): ds dump exclude _id;

- Always exclude the `_id` field from DataStore Dump blueprint.