### PR TITLE
Perform Reset Schema

### DIFF
--- a/changes/178.canada.bugfix
+++ b/changes/178.canada.bugfix
@@ -1,0 +1,1 @@
+Added a schema for performing password resets, allowing for better frameworking for password requirements and error messages.

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -444,6 +444,22 @@ def user_edit_form_schema(
 
 
 @validator_args
+def user_perform_reset_form_schema(
+        not_empty, unicode_safe, user_both_passwords_entered,
+        user_password_validator, user_passwords_match):
+    # (canada fork only): adds schema for PerformResetView
+    # TODO: upstream contrib??
+    schema = default_user_schema()
+
+    schema['password1'] = [text_type, user_both_passwords_entered,
+                           user_password_validator, user_passwords_match]
+    schema['password2'] = [text_type]
+    schema['reset_key'] = [not_empty, unicode_safe]
+
+    return schema
+
+
+@validator_args
 def default_update_user_schema(
         ignore_missing, name_validator, user_name_validator,
         unicode_safe, user_password_validator, email_is_unique,

--- a/ckan/templates/user/perform_reset.html
+++ b/ckan/templates/user/perform_reset.html
@@ -17,13 +17,15 @@
       {% block form %}
         <form action="" method="post">
           {{ form.errors(error_summary) }}
+          {# (canada fork only): add errors to field inputs #}
+          {# TODO: upstream contrib?? #}
           {% if user_dict['state'] == 'pending' %}
             <p>{{ _('You can also change username. It can not be modified later.') }}</p>
             {{ form.input("name", id="field-name", label=_("Username"), type="text", value=user_dict["name"],
-               error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+               error=errors.name, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
           {% endif %}
-          {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
-          {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+          {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error=errors.password1, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+          {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error=errors.password2, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
           <div class="form-actions">
             {% block form_button %}
             <button class="btn btn-primary" type="submit" name="save">{{ _("Update Password") }}</button>


### PR DESCRIPTION
Add in a `user_perform_reset_form_schema` schema and use it in the `PerformResetView` class instead of the view class' `_get_form_password` which prevented the framework from doing its normal schema/validation stuff.