### PR TITLE
change log level to info in default authenticator

### DIFF
--- a/changes/182.canada.changes
+++ b/changes/182.canada.changes
@@ -1,0 +1,1 @@
+Change the log level in `default_authenticate` from `debug` to `info` for the canada fork only. Related to https://github.com/open-data/ckanext-security/pull/8

--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -20,11 +20,14 @@ def default_authenticate(identity: 'Mapping[str, Any]') -> Optional["User"]:
         user_obj = User.by_email(login)
 
     if user_obj is None:
-        log.debug('Login failed - username or email %r not found', login)
+        # (canada fork only): set info level log
+        log.info('Login failed - username or email %r not found', login)
     elif not user_obj.is_active:
-        log.debug('Login as %r failed - user isn\'t active', login)
+        # (canada fork only): set info level log
+        log.info('Login as %r failed - user isn\'t active', login)
     elif not user_obj.validate_password(identity['password']):
-        log.debug('Login as %r failed - password not valid', login)
+        # (canada fork only): set info level log
+        log.info('Login as %r failed - password not valid', login)
     else:
         return user_obj
     signals.failed_login.send(login)


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Change the log level in `default_authenticate` from `debug` to `info` for the canada fork only. Related to https://github.com/open-data/ckanext-security/pull/8

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
