### PR TITLE
Filtered download bugfix

### DIFF
--- a/changes/183.canada.bugfix
+++ b/changes/183.canada.bugfix
@@ -1,0 +1,1 @@
+Display accented characters properly in Excel for filtered results downloaded using datatablesview.

--- a/ckanext/datatablesview/blueprint.py
+++ b/ckanext/datatablesview/blueprint.py
@@ -206,6 +206,7 @@ def filtered_download(resource_view_id):
                 u'filters': json.dumps(filters),
                 u'format': request.form[u'format'],
                 u'fields': u','.join(cols),
+                u'bom': True,
             }))
 
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Display accented characters properly in Excel for filtered results downloaded using datatablesview.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
