### PR TITLE
Search Index Rebuild UI and After Org Update

### DIFF
--- a/changes/185.canada.feature
+++ b/changes/185.canada.feature
@@ -1,0 +1,1 @@
+Added UI for search index rebuilding. Added background jobs for search index rebuilding.

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -44,6 +44,8 @@ def rebuild(
                                                    refresh=refresh,
                                                    defer_commit=(not commit_each)):
             if not verbose:
+                if err:
+                    click.echo('Failed to index dataset %s with error: %s' % (pkg_id, err))
                 continue
             if not err:
                 click.echo('[%s/%s] Indexed dataset %s' % (indexed, total, pkg_id))

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -38,13 +38,17 @@ def rebuild(
     u''' Rebuild search index '''
     from ckan.lib.search import rebuild, commit
     try:
-
-        rebuild(package_id,
-                only_missing=only_missing,
-                force=force,
-                refresh=refresh,
-                defer_commit=(not commit_each),
-                quiet=quiet)
+        for _pkg_id, _total, _indexed, _error in rebuild(package_id,
+                                                         only_missing=only_missing,
+                                                         force=force,
+                                                         refresh=refresh,
+                                                         defer_commit=(not commit_each)):
+            if not verbose:
+                continue
+            if not _error:
+                click.echo('[%s/%s] Indexed dataset %s' % (_indexed, _total, _pkg_id))
+            else:
+                click.echo('[%s/%s] Failed to index dataset %s with error: %s' % (_indexed, _total, _pkg_id, _error))
     except Exception as e:
         tk.error_shout(e)
     if not commit_each:

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -38,17 +38,17 @@ def rebuild(
     u''' Rebuild search index '''
     from ckan.lib.search import rebuild, commit
     try:
-        for _pkg_id, _total, _indexed, _error in rebuild(package_id,
-                                                         only_missing=only_missing,
-                                                         force=force,
-                                                         refresh=refresh,
-                                                         defer_commit=(not commit_each)):
+        for pkg_id, total, indexed, err in rebuild(package_id,
+                                                   only_missing=only_missing,
+                                                   force=force,
+                                                   refresh=refresh,
+                                                   defer_commit=(not commit_each)):
             if not verbose:
                 continue
-            if not _error:
-                click.echo('[%s/%s] Indexed dataset %s' % (_indexed, _total, _pkg_id))
+            if not err:
+                click.echo('[%s/%s] Indexed dataset %s' % (indexed, total, pkg_id))
             else:
-                click.echo('[%s/%s] Failed to index dataset %s with error: %s' % (_indexed, _total, _pkg_id, _error))
+                click.echo('[%s/%s] Failed to index dataset %s with error: %s' % (indexed, total, pkg_id, err))
     except Exception as e:
         tk.error_shout(e)
     if not commit_each:

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -466,6 +466,15 @@ class DefaultGroupForm(object):
         """
         return 'group/bulk_process.html'
 
+    # (canada fork only): background search index rebuilding
+    #TODO: upstream contrib!!
+    def search_rebuild_template(self):
+        """
+        Returns a string representing the location of the template to be
+        rendered for the search_rebuild page
+        """
+        return 'group/search_rebuild.html'
+
     def group_form(self):
         return 'group/new_group_form.html'
 
@@ -590,6 +599,11 @@ class DefaultOrganizationForm(DefaultGroupForm):
 
     def activity_template(self):
         return 'organization/activity_stream.html'
+
+    # (canada fork only): background search index rebuilding
+    #TODO: upstream contrib!!
+    def search_rebuild_template(self):
+        return 'organization/search_rebuild.html'
 
 
 class DefaultTranslation(object):

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -175,13 +175,13 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
         # (canada fork only): background search index rebuilding
         #TODO: upstream contrib!!
         total_packages = len(package_ids)
-        for counter, package_id in enumerate(package_ids):
+        for counter, package_id in enumerate(package_ids, 1):
             pkg_dict = logic.get_action('package_show')(context,
                 {'id': package_id})
             package_index.update_dict(pkg_dict, True)
             # (canada fork only): background search index rebuilding
             #TODO: upstream contrib!!
-            yield package_id, total_packages, (counter + 1), None
+            yield package_id, total_packages, counter, None
     else:
         package_ids = [r[0] for r in model.Session.query(model.Package.id).
                        filter(model.Package.state != 'deleted').all()]
@@ -203,7 +203,7 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
                 package_index.clear()
 
         total_packages = len(package_ids)
-        for counter, pkg_id in enumerate(package_ids):
+        for counter, pkg_id in enumerate(package_ids, 1):
             try:
                 package_index.update_dict(
                     logic.get_action('package_show')(context,
@@ -213,13 +213,13 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
                 )
                 # (canada fork only): background search index rebuilding
                 #TODO: upstream contrib!!
-                yield pkg_id, total_packages, (counter + 1), None
+                yield pkg_id, total_packages, counter, None
             except Exception as e:
                 log.error(u'Error while indexing dataset %s: %s' %
                           (pkg_id, repr(e)))
                 # (canada fork only): background search index rebuilding
                 #TODO: upstream contrib!!
-                yield pkg_id, total_packages, (counter + 1), str(e)
+                yield pkg_id, total_packages, counter, str(e)
                 if force:
                     log.error(text_traceback())
                     continue

--- a/ckan/lib/search/jobs.py
+++ b/ckan/lib/search/jobs.py
@@ -18,6 +18,21 @@ log = getLogger(__name__)
 
 
 def reindex_packages(package_ids=None, group_id=None):
+    """
+    Callback for a REDIS job
+
+    Uses task_status to track the state of a search.rebuild call.
+
+    This always commits each record in a forceful manner.
+
+    See ckan.lib.search.rebuild for more information.
+
+    :param package_ids: list of package IDs to pass to search.rebuild
+    :type package_ids: list
+
+    :param group_id: organization or group ID to reindex the records
+    :type group_id: string
+    """
     context = {
         'model': model,
         'ignore_auth': True,

--- a/ckan/lib/search/jobs.py
+++ b/ckan/lib/search/jobs.py
@@ -52,15 +52,15 @@ def reindex_packages(package_ids=None, group_id=None):
 
     value['job_id'] = get_current_job().id
 
-    for _dataset_id, _total, _indexed, _error in search.rebuild(force=True, package_ids=package_ids):
-        if not _error:
-            log.info('[%s/%s] Indexed dataset %s' % (_indexed, _total, _dataset_id))
+    for pkg_id, total, indexed, err in search.rebuild(force=True, package_ids=package_ids):
+        if not err:
+            log.info('[%s/%s] Indexed dataset %s' % (indexed, total, pkg_id))
         else:
-            log.error('[%s/%s] Failed to index dataset %s with error: %s' % (_indexed, _total, _dataset_id, _error))
-        value['indexed'] = _indexed
-        value['total'] = _total
-        if _error:
-            error[_dataset_id] = _error
+            log.error('[%s/%s] Failed to index dataset %s with error: %s' % (indexed, total, pkg_id, err))
+        value['indexed'] = indexed
+        value['total'] = total
+        if err:
+            error[pkg_id] = err
         task['value'] = json.dumps(value)
         task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
         logic.get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)

--- a/ckan/lib/search/jobs.py
+++ b/ckan/lib/search/jobs.py
@@ -17,7 +17,7 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-def reindex(package_ids=None, group_id=None):
+def reindex_packages(package_ids=None, group_id=None):
     context = {
         'model': model,
         'ignore_auth': True,
@@ -29,7 +29,7 @@ def reindex(package_ids=None, group_id=None):
     task = {
         'entity_id': _entity_id,
         'entity_type': 'group' if group_id else 'site',
-        'task_type': 'search_rebuild',
+        'task_type': 'reindex_packages',
         'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
         'state': 'running',
         'key': 'search_rebuild',
@@ -39,7 +39,7 @@ def reindex(package_ids=None, group_id=None):
 
     try:
         task = logic.get_action('task_status_show')(context, {'entity_id': _entity_id,
-                                                              'task_type': 'search_rebuild',
+                                                              'task_type': 'reindex_packages',
                                                               'key': 'search_rebuild'})
         task['state'] = 'running'
         task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))

--- a/ckan/lib/search/jobs.py
+++ b/ckan/lib/search/jobs.py
@@ -1,0 +1,70 @@
+# encoding: utf-8
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+
+import json
+import datetime
+from rq import get_current_job
+
+import ckan.logic as logic
+import ckan.lib.search as search
+import ckan.model as model
+
+from ckan.plugins import toolkit
+
+from logging import getLogger
+log = getLogger(__name__)
+
+
+def reindex(package_ids=None, group_id=None):
+    context = {
+        'model': model,
+        'ignore_auth': True,
+        'validate': False,
+        'use_cache': False
+    }
+
+    _entity_id = group_id if group_id else toolkit.config.get('ckan.site_id')
+    task = {
+        'entity_id': _entity_id,
+        'entity_type': 'group' if group_id else 'site',
+        'task_type': 'search_rebuild',
+        'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
+        'state': 'running',
+        'key': 'search_rebuild',
+        'value': '{}',
+        'error': '{}',
+    }
+
+    try:
+        task = logic.get_action('task_status_show')(context, {'entity_id': _entity_id,
+                                                              'task_type': 'search_rebuild',
+                                                              'key': 'search_rebuild'})
+        task['state'] = 'running'
+        task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+        logic.get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+    except logic.NotFound:
+        pass
+
+    value = json.loads(task.get('value', '{}'))
+    error = json.loads(task.get('error', '{}'))
+
+    value['job_id'] = get_current_job().id
+
+    for _dataset_id, _total, _indexed, _error in search.rebuild(force=True, package_ids=package_ids):
+        if not _error:
+            log.info('[%s/%s] Indexed dataset %s' % (_indexed, _total, _dataset_id))
+        else:
+            log.error('[%s/%s] Failed to index dataset %s with error: %s' % (_indexed, _total, _dataset_id, _error))
+        value['indexed'] = _indexed
+        value['total'] = _total
+        if _error:
+            error[_dataset_id] = _error
+        task['value'] = json.dumps(value)
+        task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+        logic.get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+
+    task['state'] = 'complete'
+    task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+    logic.get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -827,6 +827,7 @@ def _group_or_org_packages_background_reindex(context, data_dict, is_org=False):
     else:
         _check_access('reindex_group_datasets', context, data_dict)
 
+    #TODO: query for groups...
     results = session.query(model.Package.id)\
         .filter(model.Package.owner_org == group.id)\
         .filter(model.Package.state == 'active').all()

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -791,9 +791,9 @@ def _group_or_org_update(context, data_dict, is_org=False):
         if (plugins.toolkit.asbool(plugins.toolkit.config.get('ckan.search.reindex_after_group_or_org_update', False))
             and (group.title != current_title or group.name != current_name)):
             # only reindex if the title or name has changed
-            action = 'reindex_group_datasets'
+            action = 'group_packages_background_reindex'
             if is_org:
-                action = 'reindex_organization_datasets'
+                action = 'organization_packages_background_reindex'
             reindex_context = {
                 'model': model,
                 'user': user,
@@ -807,7 +807,7 @@ def _group_or_org_update(context, data_dict, is_org=False):
 
 # (canada fork only): background search index rebuilding
 #TODO: upstream contrib!!
-def _reindex_group_or_org_in_background(context, data_dict, is_org=False):
+def _group_or_org_packages_background_reindex(context, data_dict, is_org=False):
     """
     Reindexes all of an organization's or group's datasets in a background job.
     """
@@ -875,25 +875,25 @@ def _reindex_group_or_org_in_background(context, data_dict, is_org=False):
 
 # (canada fork only): background search index rebuilding
 #TODO: upstream contrib!!
-def reindex_organization_datasets_in_background(context, data_dict):
+def organization_packages_background_reindex(context, data_dict):
     """
     Reindexes all of an organization's datasets in a background job.
     """
-    return _reindex_group_or_org_in_background(context, data_dict, is_org=True)
+    return _group_or_org_packages_background_reindex(context, data_dict, is_org=True)
 
 
 # (canada fork only): background search index rebuilding
 #TODO: upstream contrib!!
-def reindex_group_datasets_in_background(context, data_dict):
+def group_packages_background_reindex(context, data_dict):
     """
     Reindexes all of a groups's datasets in a background job.
     """
-    return _reindex_group_or_org_in_background(context, data_dict)
+    return _group_or_org_packages_background_reindex(context, data_dict)
 
 
 # (canada fork only): background search index rebuilding
 #TODO: upstream contrib!!
-def reindex_site_in_background(context, data_dict):
+def site_packages_background_reindex(context, data_dict):
     """
     Reindexes all of the site's datasets in a background job.
     """

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -827,10 +827,16 @@ def _group_or_org_packages_background_reindex(context, data_dict, is_org=False):
     else:
         _check_access('reindex_group_datasets', context, data_dict)
 
-    #TODO: query for groups...
-    results = session.query(model.Package.id)\
-        .filter(model.Package.owner_org == group.id)\
-        .filter(model.Package.state == 'active').all()
+    if is_org:
+        query = session.query(model.Package.id).\
+            filter(model.Package.owner_org == group.id).\
+            filter(model.Package.state == 'active')
+    else:
+        query = session.query(model.Member.table_id.label('id')).\
+            filter(model.Member.group_id == group.id).\
+            filter(model.Member.table_name == 'package').\
+            filter(model.Member.state == 'active')
+    results = query.all()
 
     if not results:
         return

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -919,7 +919,7 @@ def reindex_site(context, data_dict):
                                       kwargs={'force': True, 'in_background': True})
 
     # let search.rebuild calculate the total...
-    task['value'] =  json.dumps({'job_id': job.id, 'total': 0, 'indexed': 0})
+    task['value'] =  json.dumps({'job_id': job.id, 'total': None, 'indexed': 0})
     task['state'] = 'pending'
     task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -27,6 +27,7 @@ import ckan.lib.search as search
 import ckan.lib.uploader as uploader
 import ckan.lib.datapreview
 import ckan.lib.app_globals as app_globals
+from ckan.lib.jobs import dictize_job
 
 
 from ckan.common import _, request, asbool
@@ -680,6 +681,11 @@ def _group_or_org_update(context, data_dict, is_org=False):
 
     data_dict['type'] = group.type
 
+    # (canada fork only): background search index rebuilding
+    #TODO: upstream contrib!!
+    current_title = group.title
+    current_name = group.name
+
     # get the schema
     group_plugin = lib_plugins.lookup_group_plugin(group.type)
     try:
@@ -777,8 +783,149 @@ def _group_or_org_update(context, data_dict, is_org=False):
 
     if not context.get('defer_commit'):
         model.repo.commit()
+        # (canada fork only): background search index rebuilding
+        #TODO: upstream contrib!!
+        if (plugins.toolkit.asbool(plugins.toolkit.config.get('ckan.search.reindex_after_group_update', False))
+            and (group.title != current_title or group.name != current_name)):
+            # only reindex if the title or name has changed
+            action = 'reindex_group_datasets'
+            if is_org:
+                action = 'reindex_organization_datasets'
+            reindex_context = {
+                'model': model,
+                'user': user,
+                'ignore_auth': True,
+                'session': session
+            }
+            _get_action(action)(reindex_context, {'id': group.id})
 
     return model_dictize.group_dictize(group, context)
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def _group_or_org_reindex(context, data_dict, is_org=False):
+    model = context['model']
+    session = context['session']
+    id = _get_or_bust(data_dict, 'id')
+
+    group = model.Group.get(id)
+    context["group"] = group
+    if group is None:
+        raise NotFound('Group was not found.')
+
+    data_dict['type'] = group.type
+
+    if is_org:
+        _check_access('reindex_organization_datasets', context, data_dict)
+    else:
+        _check_access('reindex_group_datasets', context, data_dict)
+
+    results = session.query(model.Package.id)\
+        .filter(model.Package.owner_org == group.id)\
+        .filter(model.Package.state == 'active').all()
+
+    if not results:
+        return
+
+    task = {
+        'entity_id': group.id,
+        'entity_type': 'group',
+        'task_type': 'search_rebuild',
+        'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
+        'state': 'submitting',
+        'key': 'search_rebuild',
+        'value': '{}',
+        'error': '{}',
+    }
+    try:
+        existing_task = _get_action('task_status_show')(context, {'entity_id': group.id,
+                                                                  'task_type': 'search_rebuild',
+                                                                  'key': 'search_rebuild'})
+        if existing_task.get('state') == 'pending':
+            log.info('A pending task (%s) was found for this %s (%s). Skipping this duplicate task...',
+                     existing_task['id'], 'Organization' if is_org else 'Group', group.name)
+            return False
+        task['id'] = existing_task['id']
+    except NotFound:
+        pass
+
+    _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+
+    dataset_ids = [dataset.id for dataset in results]
+    job_title = 'Rebuild Dataset Indecies for %s: %s' % ('Organization' if is_org else 'Group', group.name)
+    queue_name = plugins.toolkit.config.get('ckan.search.rebuild_queue_name', 'search_rebuild')
+
+    job = plugins.toolkit.enqueue_job(fn=search.rebuild, title=job_title, queue=queue_name,
+                                      kwargs={'force': True, 'package_ids': dataset_ids, 'in_background': True, 'group_id': group.id})
+
+    task['value'] =  json.dumps({'job_id': job.id, 'total': len(dataset_ids), 'indexed': 0})
+    task['state'] = 'pending'
+    task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+
+    _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+
+    return dictize_job(job)
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_organization_datasets(context, data_dict):
+    return _group_or_org_reindex(context, data_dict, is_org=True)
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_group_datasets(context, data_dict):
+    return _group_or_org_reindex(context, data_dict)
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_site(context, data_dict):
+    model = context['model']
+    _check_access('reindex_site', context, data_dict)
+
+    _entity_id = plugins.toolkit.config.get('ckan.site_id')
+
+    task = {
+        'entity_id': _entity_id,
+        'entity_type': 'site',
+        'task_type': 'search_rebuild',
+        'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
+        'state': 'submitting',
+        'key': 'search_rebuild',
+        'value': '{}',
+        'error': '{}',
+    }
+    try:
+        existing_task = _get_action('task_status_show')(context, {'entity_id': _entity_id,
+                                                                  'task_type': 'search_rebuild',
+                                                                  'key': 'search_rebuild'})
+        if existing_task.get('state') == 'pending':
+            log.info('A pending task (%s) was found for this Site (%s). Skipping this duplicate task...',
+                     existing_task['id'], _entity_id)
+            return False
+        task['id'] = existing_task['id']
+    except NotFound:
+        pass
+
+    _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+
+    job_title = 'Rebuild Dataset Indecies for Site: %s' % _entity_id
+    queue_name = plugins.toolkit.config.get('ckan.search.rebuild_queue_name', 'search_rebuild')
+
+    job = plugins.toolkit.enqueue_job(fn=search.rebuild, title=job_title, queue=queue_name,
+                                      kwargs={'force': True, 'in_background': True})
+
+    # let search.rebuild calculate the total...
+    task['value'] =  json.dumps({'job_id': job.id, 'total': 0, 'indexed': 0})
+    task['state'] = 'pending'
+    task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+
+    _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
+
+    return dictize_job(job)
 
 
 def group_update(context, data_dict):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -837,7 +837,7 @@ def _reindex_group_or_org_in_background(context, data_dict, is_org=False):
     task = {
         'entity_id': group.id,
         'entity_type': 'group',
-        'task_type': 'search_rebuild',
+        'task_type': 'reindex_packages',
         'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
         'state': 'submitting',
         'key': 'search_rebuild',
@@ -846,7 +846,7 @@ def _reindex_group_or_org_in_background(context, data_dict, is_org=False):
     }
     try:
         existing_task = _get_action('task_status_show')(context, {'entity_id': group.id,
-                                                                  'task_type': 'search_rebuild',
+                                                                  'task_type': 'reindex_packages',
                                                                   'key': 'search_rebuild'})
         if existing_task.get('state') == 'pending':
             log.info('A pending task (%s) was found for this %s (%s). Skipping this duplicate task...',
@@ -867,7 +867,7 @@ def _reindex_group_or_org_in_background(context, data_dict, is_org=False):
     _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
 
     queue_name = plugins.toolkit.config.get('ckan.search.rebuild_queue_name', 'search_rebuild')
-    job = plugins.toolkit.enqueue_job(fn=search_jobs.reindex, title=_('Rebuild Dataset Indices'), queue=queue_name,
+    job = plugins.toolkit.enqueue_job(fn=search_jobs.reindex_packages, title=_('Rebuild Dataset Indices'), queue=queue_name,
                                       kwargs={'package_ids': dataset_ids, 'group_id': group.id})
 
     return dictize_job(job)
@@ -905,7 +905,7 @@ def reindex_site_in_background(context, data_dict):
     task = {
         'entity_id': _entity_id,
         'entity_type': 'site',
-        'task_type': 'search_rebuild',
+        'task_type': 'reindex_packages',
         'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
         'state': 'submitting',
         'key': 'search_rebuild',
@@ -914,7 +914,7 @@ def reindex_site_in_background(context, data_dict):
     }
     try:
         existing_task = _get_action('task_status_show')(context, {'entity_id': _entity_id,
-                                                                  'task_type': 'search_rebuild',
+                                                                  'task_type': 'reindex_packages',
                                                                   'key': 'search_rebuild'})
         if existing_task.get('state') == 'pending':
             log.info('A pending task (%s) was found for this Site (%s). Skipping this duplicate task...',
@@ -934,7 +934,7 @@ def reindex_site_in_background(context, data_dict):
     _get_action('task_status_update')({'session': model.meta.create_local_session(), 'ignore_auth': True}, task)
 
     queue_name = plugins.toolkit.config.get('ckan.search.rebuild_queue_name', 'search_rebuild')
-    job = plugins.toolkit.enqueue_job(fn=search_jobs.reindex, title=_('Rebuild Dataset Indices'), queue=queue_name)
+    job = plugins.toolkit.enqueue_job(fn=search_jobs.reindex_packages, title=_('Rebuild Dataset Indices'), queue=queue_name)
 
     return dictize_job(job)
 

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -151,18 +151,18 @@ def organization_update(context, data_dict):
 #TODO: upstream contrib!!
 def reindex_organization_datasets(context, data_dict):
     """
-    Only sysadmins can perform reindexing
+    If you have permission to edit the Organization, you can reindex it.
     """
-    return {'success': False}
+    return authz.is_authorized('organization_update', context, data_dict)
 
 
 # (canada fork only): background search index rebuilding
 #TODO: upstream contrib!!
 def reindex_group_datasets(context, data_dict):
     """
-    Only sysadmins can perform reindexing
+    If you have permission to edit the Group, you can reindex it.
     """
-    return {'success': False}
+    return authz.is_authorized('group_update', context, data_dict)
 
 
 # (canada fork only): background search index rebuilding

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -147,6 +147,33 @@ def organization_update(context, data_dict):
         return {'success': True}
 
 
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_organization_datasets(context, data_dict):
+    """
+    Only sysadmins can perform reindexing
+    """
+    return {'success': False}
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_group_datasets(context, data_dict):
+    """
+    Only sysadmins can perform reindexing
+    """
+    return {'success': False}
+
+
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def reindex_site(context, data_dict):
+    """
+    Only sysadmins can perform reindexing
+    """
+    return {'success': False}
+
+
 def group_change_state(context, data_dict):
     user = context['user']
     group = logic_auth.get_group_object(context, data_dict)

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -10905,3 +10905,14 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+div[data-module="progress-bar"] .progress{
+  margin-bottom: 0;
+}
+div[data-module="progress-bar"] .progress-bar{
+  transition: none;
+}
+div[data-module="progress-bar"] .progress-bar-label{
+  display: block;
+  text-align: right;
+  margin-bottom: 23px;
+}

--- a/ckan/public/base/javascript/modules/progress-bar.js
+++ b/ckan/public/base/javascript/modules/progress-bar.js
@@ -28,6 +28,9 @@ this.ckan.module('progress-bar', function ($) {
           if( label.length > 0 ){
             $(progressBarLabel).text(label);
           }
+          if( ! _total || ! _current ){
+            return
+          }
           let val = (_total / _current) * 100;
           if( _total != _current ){
             $(progressBar).animate({'width': val + '%'}, 635);

--- a/ckan/public/base/javascript/modules/progress-bar.js
+++ b/ckan/public/base/javascript/modules/progress-bar.js
@@ -1,0 +1,81 @@
+this.ckan.module('progress-bar', function ($) {
+  return {
+    options: {
+      endpoint: '',
+      percentage: false,
+    },
+
+    initialize: function () {
+      let options = this.options;
+      let el = this.el;
+
+      if( options.endpoint.length > 0 ){
+
+        $(el).append('<div class="progress"><div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div></div><small class="progress-bar-label"></small>');
+        let progressBar = $(el).find('.progress-bar');
+        let progressBarLabel = $(el).find('.progress-bar-label');
+
+        function update_bar(_total, _current, _label, _timestamp){
+          let label = '';
+          if( _label.length > 0 ){
+            label = _label;
+            if( _timestamp.length > 0 ){
+              label += ' (' + _timestamp + ')';
+            }
+          }else if( _timestamp.length > 0 ){
+            label = _timestamp;
+          }
+          if( label.length > 0 ){
+            $(progressBarLabel).text(label);
+          }
+          let val = (_total / _current) * 100;
+          if( _total != _current ){
+            $(progressBar).animate({'width': val + '%'}, 635);
+          }else{
+            $(progressBar).css({'width': val + '%'});
+          }
+          if( options.percentage != false ){
+            $(progressBar).text(val + '%');
+            $(progressBar).attr('aria-valuenow', val);
+          }else{
+            $(progressBar).text(_current + '/' + _total);
+            $(progressBar).attr('aria-valuemax', _total);
+            $(progressBar).attr('aria-valuenow', _current);
+          }
+        }
+
+        function heartbeat(){
+          $.ajax({
+            'url': options.endpoint,
+            'type': 'GET',
+            'dataType': 'JSON',
+            'complete': function(_data){
+              if( _data.responseJSON ){  // we have response JSON
+                // label should be optional
+                _label = '';
+                if( typeof _data.responseJSON.label != 'undefined' ){
+                  _label = _data.responseJSON.label
+                }
+                // last updated should be optional
+                _timestamp = '';
+                if( typeof _data.responseJSON.last_updated != 'undefined' ){
+                  _timestamp = _data.responseJSON.last_updated
+                }
+                update_bar(_data.responseJSON.total, _data.responseJSON.current, _label, _timestamp);
+                if( _data.responseJSON.total != _data.responseJSON.current){
+                  setTimeout(heartbeat, 5000);
+                }
+              }else{  // fully flopped ajax request
+                // just try again...
+                setTimeout(heartbeat, 5000);
+              }
+            }
+          });
+        }
+
+        heartbeat();
+
+      }
+    }
+  };
+});

--- a/ckan/public/base/javascript/webassets.yml
+++ b/ckan/public/base/javascript/webassets.yml
@@ -57,6 +57,9 @@ ckan:
     - modules/followers-counter.js
     - modules/metadata-button.js
     - modules/copy-into-buffer.js
+    # (canada fork only): background search index rebuilding
+    #TODO: upstream contrib!!
+    - modules/progress-bar.js
 
 tracking:
   output: base/%(version)s_tracking.js

--- a/ckan/templates/admin/base.html
+++ b/ckan/templates/admin/base.html
@@ -8,5 +8,6 @@
   {{ h.build_nav_icon('admin.index', _('Sysadmins'), icon='gavel') }}
   {{ h.build_nav_icon('admin.config', _('Config'), icon='check-square-o') }}
   {{ h.build_nav_icon('admin.trash', _('Trash'), icon='trash-o') }}
+  {{ h.build_nav_icon('admin.search_rebuild', _('Rebuild Search Index'), icon='database') }}
   {{ h.build_extra_admin_nav() }}
 {% endblock %}

--- a/ckan/templates/admin/search_rebuild.html
+++ b/ckan/templates/admin/search_rebuild.html
@@ -1,0 +1,20 @@
+{% extends "admin/base.html" %}
+
+{% block subtitle %}{{ _("Rebuild Search Index") }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% block secondary_help %}
+    <div class="module module-narrow module-shallow">
+      <h2 class="module-heading">
+        <i class="fa fa-lg fa-info-circle"></i>
+        {{ _('Why re-index?') }}
+      </h2>
+      <div class="module-content">
+        {% trans %}
+          <p></p>
+        {% endtrans %}
+      </div>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/ckan/templates/admin/search_rebuild.html
+++ b/ckan/templates/admin/search_rebuild.html
@@ -1,6 +1,27 @@
+{# (canada fork only): background search index rebuilding #}
+{#  TODO: upstream contrib!! #}
 {% extends "admin/base.html" %}
 
 {% block subtitle %}{{ _("Rebuild Search Index") }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=site_id) }}"></div>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {% if 'csrf_input' in h %}
+      {{ h.csrf_input() }}
+    {% endif %}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this site? This can take a long time if the site has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Site\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
 
 {% block secondary_content %}
   {{ super() }}
@@ -12,7 +33,7 @@
       </h2>
       <div class="module-content">
         {% trans %}
-          <p></p>
+          <p>The SOLR index is used for searching datasets and search facets. In the case that some datasets are not showing in the search or a search facet is not working, you can try to re-index the site.</p>
         {% endtrans %}
       </div>
     </div>

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -21,7 +21,7 @@
   {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
   {# (canada fork only): background search index rebuilding #}
   {#  TODO: upstream contrib!! #}
-  {% if h.check_access('sysadmin') %}
+  {% if group_dict and h.check_access('reindex_group_datasets', {'id': group_dict.id}) %}
     {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
   {% endif %}
 {% endblock %}

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -19,6 +19,11 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil') }}
   {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
+  {# (canada fork only): background search index rebuilding #}
+  {#  TODO: upstream contrib!! #}
+  {% if h.check_access('sysadmin') %}
+    {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
+  {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/group/search_rebuild.html
+++ b/ckan/templates/group/search_rebuild.html
@@ -25,18 +25,20 @@
 
 {% block secondary_content %}
   {{ super() }}
-  {% block secondary_help %}
-    <div class="module module-narrow module-shallow">
-      <h2 class="module-heading">
-        <i class="fa fa-lg fa-info-circle"></i>
-        {{ _('Why re-index?') }}
-      </h2>
-      <div class="module-content">
-        {% trans %}
-          <p>If you update an Group's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
-          <p>To solve this, you can re-index all of the Group's records in a background job.</p>
-        {% endtrans %}
+  {% if not has_auto_index %}
+    {% block secondary_help %}
+      <div class="module module-narrow module-shallow">
+        <h2 class="module-heading">
+          <i class="fa fa-lg fa-info-circle"></i>
+          {{ _('Why re-index?') }}
+        </h2>
+        <div class="module-content">
+          {% trans %}
+            <p>If you update an Group's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+            <p>To solve this, you can re-index all of the Group's records in a background job.</p>
+          {% endtrans %}
+        </div>
       </div>
-    </div>
-  {% endblock %}
+    {% endblock %}
+  {% endif %}
 {% endblock %}

--- a/ckan/templates/group/search_rebuild.html
+++ b/ckan/templates/group/search_rebuild.html
@@ -1,0 +1,55 @@
+{# (canada fork only): background search index rebuilding #}
+{#  TODO: upstream contrib!! #}
+{% extends "group/edit_base.html" %}
+
+{% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {%- set messages = {
+    'pending': _('In queue to re-index records.'),
+    'running': _('Currently re-indexing records.'),
+    'complete': _('All records indexed.'),
+    'unknown': _('Unknown')
+  } -%}
+  {%- set colors = {
+    'pending': 'info',
+    'running': 'primary',
+    'complete': 'success',
+    'unknown': 'secondary'
+  } -%}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12 text-{{ colors.get(job_info.get('state', 'unknown')) }}">
+        <p><strong>{{ messages.get(job_info.get('state', 'unknown')) }}</strong></p>
+        <p><em>{{ job_info.get('value', {}).get('indexed', _('N/A')) }}/{{ job_info.get('value', {}).get('total', _('N/A')) }}</em></p>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {% if 'csrf_input' in h %}
+      {{ h.csrf_input() }}
+    {% endif %}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this group? This can take a long time if the group has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Group\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% block secondary_help %}
+    <div class="module module-narrow module-shallow">
+      <h2 class="module-heading">
+        <i class="fa fa-lg fa-info-circle"></i>
+        {{ _('Why re-index?') }}
+      </h2>
+      <div class="module-content">
+        {% trans %}
+          <p>If you update an Group's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+          <p>To solve this, you can re-index all of the Group's records in a background job.</p>
+        {% endtrans %}
+      </div>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/ckan/templates/group/search_rebuild.html
+++ b/ckan/templates/group/search_rebuild.html
@@ -5,23 +5,10 @@
 {% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {%- set messages = {
-    'pending': _('In queue to re-index records.'),
-    'running': _('Currently re-indexing records.'),
-    'complete': _('All records indexed.'),
-    'unknown': _('Unknown')
-  } -%}
-  {%- set colors = {
-    'pending': 'info',
-    'running': 'primary',
-    'complete': 'success',
-    'unknown': 'secondary'
-  } -%}
   {% if job_info %}
     <div class="row">
-      <div class="col-md-12 text-{{ colors.get(job_info.get('state', 'unknown')) }}">
-        <p><strong>{{ messages.get(job_info.get('state', 'unknown')) }}</strong></p>
-        <p><em>{{ job_info.get('value', {}).get('indexed', _('N/A')) }}/{{ job_info.get('value', {}).get('total', _('N/A')) }}</em></p>
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=group_dict.get('id')) }}"></div>
       </div>
     </div>
     <hr />

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -24,7 +24,7 @@
     {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
     {# (canada fork only): background search index rebuilding #}
     {#  TODO: upstream contrib!! #}
-    {% if h.check_access('sysadmin') %}
+    {% if organization and h.check_access('reindex_organization_datasets', {'id': organization.id}) %}
       {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
     {% endif %}
 {% endblock %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -22,6 +22,11 @@
     {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil') }}
     {{ h.build_nav_icon(group_type + '.bulk_process', h.humanize_entity_type('package', dataset_type, 'content tab') or _('Datasets'), id=group_dict.name, icon='sitemap') }}
     {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
+    {# (canada fork only): background search index rebuilding #}
+    {#  TODO: upstream contrib!! #}
+    {% if h.check_access('sysadmin') %}
+      {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
+    {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/search_rebuild.html
+++ b/ckan/templates/organization/search_rebuild.html
@@ -1,0 +1,55 @@
+{# (canada fork only): background search index rebuilding #}
+{#  TODO: upstream contrib!! #}
+{% extends "organization/edit_base.html" %}
+
+{% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {%- set messages = {
+    'pending': _('In queue to re-index records.'),
+    'running': _('Currently re-indexing records.'),
+    'complete': _('All records indexed.'),
+    'unknown': _('Unknown')
+  } -%}
+  {%- set colors = {
+    'pending': 'info',
+    'running': 'primary',
+    'complete': 'success',
+    'unknown': 'secondary'
+  } -%}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12 text-{{ colors.get(job_info.get('state', 'unknown')) }}">
+        <p><strong>{{ messages.get(job_info.get('state', 'unknown')) }}</strong></p>
+        <p><em>{{ job_info.get('value', {}).get('indexed', _('N/A')) }}/{{ job_info.get('value', {}).get('total', _('N/A')) }}</em></p>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {% if 'csrf_input' in h %}
+      {{ h.csrf_input() }}
+    {% endif %}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this organization? This can take a long time if the organization has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Organization\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% block secondary_help %}
+    <div class="module module-narrow module-shallow">
+      <h2 class="module-heading">
+        <i class="fa fa-lg fa-info-circle"></i>
+        {{ _('Why re-index?') }}
+      </h2>
+      <div class="module-content">
+        {% trans %}
+          <p>If you update an Organization's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+          <p>To solve this, you can re-index all of the Organization's records in a background job.</p>
+        {% endtrans %}
+      </div>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/ckan/templates/organization/search_rebuild.html
+++ b/ckan/templates/organization/search_rebuild.html
@@ -25,18 +25,20 @@
 
 {% block secondary_content %}
   {{ super() }}
-  {% block secondary_help %}
-    <div class="module module-narrow module-shallow">
-      <h2 class="module-heading">
-        <i class="fa fa-lg fa-info-circle"></i>
-        {{ _('Why re-index?') }}
-      </h2>
-      <div class="module-content">
-        {% trans %}
-          <p>If you update an Organization's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
-          <p>To solve this, you can re-index all of the Organization's records in a background job.</p>
-        {% endtrans %}
+  {% if not has_auto_index %}
+    {% block secondary_help %}
+      <div class="module module-narrow module-shallow">
+        <h2 class="module-heading">
+          <i class="fa fa-lg fa-info-circle"></i>
+          {{ _('Why re-index?') }}
+        </h2>
+        <div class="module-content">
+          {% trans %}
+            <p>If you update an Organization's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+            <p>To solve this, you can re-index all of the Organization's records in a background job.</p>
+          {% endtrans %}
+        </div>
       </div>
-    </div>
-  {% endblock %}
+    {% endblock %}
+  {% endif %}
 {% endblock %}

--- a/ckan/templates/organization/search_rebuild.html
+++ b/ckan/templates/organization/search_rebuild.html
@@ -5,23 +5,10 @@
 {% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {%- set messages = {
-    'pending': _('In queue to re-index records.'),
-    'running': _('Currently re-indexing records.'),
-    'complete': _('All records indexed.'),
-    'unknown': _('Unknown')
-  } -%}
-  {%- set colors = {
-    'pending': 'info',
-    'running': 'primary',
-    'complete': 'success',
-    'unknown': 'secondary'
-  } -%}
   {% if job_info %}
     <div class="row">
-      <div class="col-md-12 text-{{ colors.get(job_info.get('state', 'unknown')) }}">
-        <p><strong>{{ messages.get(job_info.get('state', 'unknown')) }}</strong></p>
-        <p><em>{{ job_info.get('value', {}).get('indexed', _('N/A')) }}/{{ job_info.get('value', {}).get('total', _('N/A')) }}</em></p>
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=group_dict.get('id')) }}"></div>
       </div>
     </div>
     <hr />

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -274,7 +274,7 @@ def search_rebuild():
     try:
         _entity_id = plugins.toolkit.config.get('ckan.site_id')
         task = plugins.toolkit.get_action('task_status_show')(context, {'entity_id': _entity_id,
-                                                              'task_type': 'search_rebuild',
+                                                              'task_type': 'reindex_packages',
                                                               'key': 'search_rebuild'})
         task['value'] = json.loads(task.get('value', '{}'))
     except logic.NotFound:

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -262,7 +262,7 @@ def search_rebuild():
 
     if request.method == 'POST':
         try:
-            job_dict = plugins.toolkit.get_action('reindex_site')(context, {})
+            job_dict = plugins.toolkit.get_action('reindex_site_in_background')(context, {})
             if job_dict:
                 h.flash_success(_('Records are in queue to be re-indexed.'))
             else:

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -272,7 +272,6 @@ def search_rebuild():
 
     task = None
     try:
-        #FIXME: task status not updated to pending from reindex_<type>_datasets, need session flush??
         _entity_id = plugins.toolkit.config.get('ckan.site_id')
         task = plugins.toolkit.get_action('task_status_show')(context, {'entity_id': _entity_id,
                                                               'task_type': 'search_rebuild',
@@ -281,7 +280,8 @@ def search_rebuild():
     except logic.NotFound:
         pass
 
-    extra_vars = {'job_info': task}
+    extra_vars = {'job_info': task,
+                  'site_id': _entity_id}
 
     return base.render('admin/search_rebuild.html', extra_vars)
 

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -262,7 +262,7 @@ def search_rebuild():
 
     if request.method == 'POST':
         try:
-            job_dict = plugins.toolkit.get_action('reindex_site_in_background')(context, {})
+            job_dict = plugins.toolkit.get_action('site_packages_background_reindex')(context, {})
             if job_dict:
                 h.flash_success(_('Records are in queue to be re-indexed.'))
             else:

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1406,9 +1406,10 @@ def register_dataset_plugin_rules(blueprint):
         u'/unfollow/<id>', view_func=unfollow, methods=(u'POST', )
     )
     blueprint.add_url_rule(u'/followers/<id>', view_func=followers)
-    blueprint.add_url_rule(
-        u'/groups/<id>', view_func=GroupView.as_view(str(u'groups'))
-    )
+    # (canada fork only): disable group views
+    # blueprint.add_url_rule(
+    #     u'/groups/<id>', view_func=GroupView.as_view(str(u'groups'))
+    # )
     blueprint.add_url_rule(u'/activity/<id>', view_func=activity)
     blueprint.add_url_rule(u'/changes/<id>', view_func=changes)
     blueprint.add_url_rule(u'/<id>/history', view_func=history)

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1198,9 +1198,9 @@ def search_rebuild(group_type, is_organization, id=None):
 
     if request.method == 'POST':
         try:
-            action = 'reindex_group_datasets_in_background'
+            action = 'group_packages_background_reindex'
             if is_organization:
-                action = 'reindex_organization_datasets_in_background'
+                action = 'organization_packages_background_reindex'
             job_dict = get_action(action)(context, {'id': id})
             if job_dict:
                 h.flash_success(_('Records are in queue to be re-indexed.'))

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1198,9 +1198,9 @@ def search_rebuild(group_type, is_organization, id=None):
 
     if request.method == 'POST':
         try:
-            action = 'reindex_group_datasets'
+            action = 'reindex_group_datasets_in_background'
             if is_organization:
-                action = 'reindex_organization_datasets'
+                action = 'reindex_organization_datasets_in_background'
             job_dict = get_action(action)(context, {'id': id})
             if job_dict:
                 h.flash_success(_('Records are in queue to be re-indexed.'))
@@ -1227,6 +1227,9 @@ def search_rebuild(group_type, is_organization, id=None):
         'group_type': group_type,
         'group_dict': group_dict,
         'job_info': task,
+        'has_auto_index':
+            plugins.toolkit.asbool(
+                plugins.toolkit.config.get('ckan.search.reindex_after_group_or_org_update', False))
     }
 
     return base.render(

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1213,7 +1213,6 @@ def search_rebuild(group_type, is_organization, id=None):
 
     task = None
     try:
-        #FIXME: task status not updated to pending from reindex_<type>_datasets, need session flush??
         task = logic.get_action('task_status_show')(context, {'entity_id': group_dict.get('id'),
                                                               'task_type': 'search_rebuild',
                                                               'key': 'search_rebuild'})

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1214,7 +1214,7 @@ def search_rebuild(group_type, is_organization, id=None):
     task = None
     try:
         task = logic.get_action('task_status_show')(context, {'entity_id': group_dict.get('id'),
-                                                              'task_type': 'search_rebuild',
+                                                              'task_type': 'reindex_packages',
                                                               'key': 'search_rebuild'})
         task['value'] = json.loads(task.get('value', '{}'))
     except NotFound:

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -4,6 +4,10 @@ import logging
 import re
 from collections import OrderedDict
 
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+import json
+
 import six
 from six import string_types
 from six.moves.urllib.parse import urlencode
@@ -1166,6 +1170,70 @@ class MembersGroupView(MethodView):
                            extra_vars)
 
 
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def search_rebuild(group_type, is_organization, id=None):
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': g.user,
+        'for_view': True,
+    }
+
+    try:
+        if is_organization:
+            _check_access('reindex_organization_datasets', context)
+        else:
+            _check_access('reindex_group_datasets', context)
+    except NotAuthorized:
+        return base.abort(403, _('Not authorized to see this page'))
+
+    try:
+        if is_organization:
+            group_dict = get_action('organization_show')(context, {'id': id})
+        else:
+            group_dict = get_action('group_show')(context, {'id': id})
+    except (NotAuthorized, NotFound):
+        return base.abort(404, _('Group not found'))
+
+    if request.method == 'POST':
+        try:
+            action = 'reindex_group_datasets'
+            if is_organization:
+                action = 'reindex_organization_datasets'
+            job_dict = get_action(action)(context, {'id': id})
+            if job_dict:
+                h.flash_success(_('Records are in queue to be re-indexed.'))
+            elif job_dict is None:
+                h.flash_notice(_('There are no records to index.'))
+            else:
+                h.flash_notice(_('Records already in queue to be re-indexed.'))
+        except (NotAuthorized, NotFound):
+            h.flash_error(_('Unable to re-index records.'))
+
+    task = None
+    try:
+        #FIXME: task status not updated to pending from reindex_<type>_datasets, need session flush??
+        task = logic.get_action('task_status_show')(context, {'entity_id': group_dict.get('id'),
+                                                              'task_type': 'search_rebuild',
+                                                              'key': 'search_rebuild'})
+        task['value'] = json.loads(task.get('value', '{}'))
+    except NotFound:
+        pass
+
+    # TODO: Remove in 2.11??
+    g.group_dict = group_dict
+
+    extra_vars = {
+        'group_type': group_type,
+        'group_dict': group_dict,
+        'job_info': task,
+    }
+
+    return base.render(
+        _get_group_template('search_rebuild_template', group_type), extra_vars)
+
+
 group = Blueprint(u'group', __name__, url_prefix=u'/group',
                   url_defaults={u'group_type': u'group',
                                 u'is_organization': False})
@@ -1203,6 +1271,12 @@ def register_group_plugin_rules(blueprint):
         u'/delete/<id>',
         methods=[u'GET', u'POST'],
         view_func=DeleteGroupView.as_view(str(u'delete')))
+    # (canada fork only): background search index rebuilding
+    #TODO: upstream contrib!!
+    blueprint.add_url_rule(
+        '/search_rebuild/<id>',
+        methods=['GET', 'POST'],
+        view_func=search_rebuild)
     for action in actions:
         blueprint.add_url_rule(
             u'/{0}/<id>'.format(action),

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -8,6 +8,13 @@ import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
 from ckan.common import _, request
 
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+import json
+from ckan.plugins import toolkit
+from ckan import model
+from ckan.views.api import _finish_ok, _finish_not_authz, _finish_not_found
+
 
 util = Blueprint(u'util', __name__)
 
@@ -35,6 +42,47 @@ def primer():
     return base.render(u'development/primer.html')
 
 
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+def search_rebuild_progress(entity_id):
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': toolkit.g.user,
+    }
+
+    try:
+        task_status = toolkit.get_action('task_status_show')(context, {'entity_id': entity_id,
+                                                                       'task_type': 'search_rebuild',
+                                                                       'key': 'search_rebuild'})
+    except toolkit.NotAuthorized:
+        return _finish_not_authz()
+    except toolkit.ObjectNotFound:
+        return _finish_not_found()
+
+    task_status['value'] = json.loads(task_status.get('value', '{}'))
+    task_status['error'] = json.loads(task_status.get('error', '{}'))
+
+    messages = {
+        'pending': _('In queue to re-index records'),
+        'running': _('Currently re-indexing records'),
+        'complete': _('All records indexed'),
+        'unknown': _('Unknown'),
+    }
+
+    return_dict = {
+        'total': task_status.get('value', {}).get('total', 0),
+        'current': task_status.get('value', {}).get('indexed', 0),
+        'label': messages.get(task_status.get('state', 'unknown')),
+        'last_updated': h.render_datetime(task_status.get('last_updated'), '%Y-%m-%d %H:%M:%S %Z') if task_status.get('last_updated') else None,
+    }
+
+    return _finish_ok(return_dict)
+
+
 util.add_url_rule(
     u'/util/redirect', view_func=internal_redirect, methods=(u'GET', u'POST',))
 util.add_url_rule(u'/testing/primer', view_func=primer)
+# (canada fork only): background search index rebuilding
+#TODO: upstream contrib!!
+util.add_url_rule('/util/search_rebuild_progress/<entity_id>', view_func=search_rebuild_progress, methods=['GET'])

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -53,7 +53,7 @@ def search_rebuild_progress(entity_id):
 
     try:
         task_status = toolkit.get_action('task_status_show')(context, {'entity_id': entity_id,
-                                                                       'task_type': 'search_rebuild',
+                                                                       'task_type': 'reindex_packages',
                                                                        'key': 'search_rebuild'})
     except toolkit.NotAuthorized:
         return _finish_not_authz()


### PR DESCRIPTION
Related issues:
* https://github.com/ckan/ckan/issues/7722
* https://github.com/ckan/ckan/issues/5842

Basic issue is that the Org/Group names are in dataset SOLR records. This would be an issue if an Org/Group title or name is updated, their dataset's won't show this in `package_search` or anything else that queries the SOLR index. So this adds some logic functions to re-index an Org/Group's records after the title or name changes.

It does this in a background task. So this would require some documentation regarding that. 

This also implements some task_status stuff for this and adds in some UIs to sysadmins to be able to re-index from the Admin views. And adds a progress bar to see the status of the re-index.