### PR TITLE
No Password Reset for Deleted Users

### DIFF
--- a/changes/187.canada.bugfix
+++ b/changes/187.canada.bugfix
@@ -1,0 +1,1 @@
+Do not allow password reset for Deleted users.

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -762,6 +762,12 @@ class RequestResetView(MethodView):
                      .format(id))
 
         for user_obj in user_objs:
+            # (canada fork only): skip deleted users
+            # TODO: upstream contrib?
+            if user_obj.state == 'deleted':
+                log.info('Cannot reset password for deleted user: {}'.format(
+                    user_obj.name))
+                continue
             log.info(u'Emailing reset link to user: {}'
                      .format(user_obj.name))
             try:


### PR DESCRIPTION
fix(views): password reset deleted users;

- Skip deleted users for password reset.