### PR TITLE
Pass DataStore Upsert Original pSQL Error Messages

### DIFF
--- a/changes/188.canada.changes
+++ b/changes/188.canada.changes
@@ -1,0 +1,1 @@
+DataStore upsert error dicts now pass the original pSQL error message and code stored in `upsert_info`

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -123,6 +123,12 @@ _engines = {}
 # (canada fork only): parse constraint sql errors
 # TODO: upstream contrib!!
 class PartialFormat(Dict[Any, Any]):
+    """
+    String Formatter class for partial format replacements.
+
+    Allows for a string to be formatted without all of
+    the expected formatting keys.
+    """
     def __missing__(self, key: str) -> str:
         return "{" + key + "}"
 
@@ -158,6 +164,8 @@ def _parse_constraint_error_from_psql_error(exception: Exception,
     ref_resource = table_match.group(1) if table_match else None
     error_message = toolkit._(error_message)  # gettext before formatting
     formatter = string.Formatter()
+    # partial replacements to handle custom error messages
+    # that may not contain all the replacement keys.
     mapping = PartialFormat(refKeys=ref_keys,
                             refValues=ref_values,
                             refTable=ref_resource)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -418,7 +418,7 @@ def _get_foreign_constraints(connection, resource_id, return_constraint_names=Fa
             ORDER BY p.oid;
         '''.format(literal_string(resource_id)))
         foreign_constraints_results = connection.execute(foreign_constraints_sql)
-        foreign_constraints += foreign_constraints_results.fetchall()
+        foreign_constraints += [r.constraint_name for r in foreign_constraints_results.fetchall()]
     else:
         foreign_constraints_sql = sa.text('''
             SELECT

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1479,9 +1479,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
             # TODO: upstream contrib!!
             errmsg = _programming_error_summary(err)
             if 'violates foreign key constraint' in errmsg:
-                errmsg = 'Cannot insert records ({refValues}) because '\
-                         'they do not exist in the referenced table. '\
-                         'Referencing {refKeys} from {refTable}.'
+                _ = lambda x:x
+                errmsg = _(
+                    'Cannot insert records ({refValues}) because '\
+                    'they do not exist in the referenced table. '\
+                    'Referencing {refKeys} from {refTable}.')
                 raise ValidationError(dict(
                     _parse_constraint_error_from_psql_error(err, errmsg),
                     records_row=num))
@@ -1582,9 +1584,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                     # TODO: upstream contrib!!
                     errmsg = _programming_error_summary(err)
                     if 'violates foreign key constraint' in errmsg:
-                        errmsg = 'Cannot insert records ({refValues}) because '\
-                                 'they do not exist in the referenced table. '\
-                                 'Referencing {refKeys} from {refTable}.'
+                        _ = lambda x:x
+                        errmsg = _(
+                            'Cannot insert records ({refValues}) because '\
+                            'they do not exist in the referenced table. '\
+                            'Referencing {refKeys} from {refTable}.')
                         raise ValidationError(dict(
                             _parse_constraint_error_from_psql_error(err, errmsg),
                             records_row=num))
@@ -1638,9 +1642,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                     # TODO: upstream contrib!!
                     errmsg = _programming_error_summary(err)
                     if 'violates foreign key constraint' in errmsg:
-                        errmsg = 'Cannot insert records ({refValues}) because '\
-                                 'they do not exist in the referenced table. '\
-                                 'Referencing {refKeys} from {refTable}.'
+                        _ = lambda x:x
+                        errmsg = _(
+                            'Cannot insert records ({refValues}) because '\
+                            'they do not exist in the referenced table. '\
+                            'Referencing {refKeys} from {refTable}.')
                         raise ValidationError(dict(
                             _parse_constraint_error_from_psql_error(err, errmsg),
                             records_row=num))
@@ -2473,9 +2479,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             if e.orig.pgcode == _PG_ERR_CODE['no_unique_constraint']:
                 # (canada fork only): parse constraint sql errors
                 # TODO: upstream contrib!!
-                errmsg = 'Cannot insert records ({refValues}) or create index because '\
-                         'they do not exist in the referenced table. '\
-                         'Referencing {refKeys} from {refTable}.'
+                _ = lambda x:x
+                errmsg = _(
+                    'Cannot insert records ({refValues}) or create index because '\
+                    'they do not exist in the referenced table. '\
+                    'Referencing {refKeys} from {refTable}.')
                 raise ValidationError(_parse_constraint_error_from_psql_error(e, errmsg))
             raise
         except DataError as e:

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2394,9 +2394,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 if e.orig.pgcode == _PG_ERR_CODE['row_referenced_constraint'] or e.orig.pgcode == _PG_ERR_CODE['table_referenced_constraint']:
                     # (canada fork only): parse constraint sql errors
                     # TODO: upstream contrib!!
-                    errmsg = 'Cannot delete records or table because of '\
-                             'a reference to another table. '\
-                             'Referencing {refKeys}({refValues}) from {refTable}.'
+                    _ = lambda x:x
+                    errmsg = _(
+                        'Cannot delete records or table because of '
+                        'a reference to another table. '
+                        'Referencing {refKeys}({refValues}) from {refTable}.')
                     raise ValidationError(_parse_constraint_error_from_psql_error(e, errmsg))
                 raise
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1353,6 +1353,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
         except (DatabaseError, DataError) as err:
             raise ValidationError({
                 'records': [_programming_error_summary(err)],
+                # (canada fork only): extra info for upsert
+                'upsert_info': {
+                    'orig': str(err.orig),
+                    'pgcode': err.orig.pgcode
+                },
                 'records_row': num,
             })
 
@@ -1446,6 +1451,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 except DatabaseError as err:
                     raise ValidationError({
                         'records': [_programming_error_summary(err)],
+                        # (canada fork only): extra info
+                        'upsert_info': {
+                            'orig': str(err.orig),
+                            'pgcode': err.orig.pgcode
+                        },
                         'records_row': num,
                     })
 
@@ -1492,6 +1502,11 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 except DatabaseError as err:
                     raise ValidationError({
                         'records': [_programming_error_summary(err)],
+                        # (canada fork only): extra info
+                        'upsert_info': {
+                            'orig': str(err.orig),
+                            'pgcode': err.orig.pgcode
+                        },
                         'records_row': num,
                     })
 


### PR DESCRIPTION
feat(logic): ds upsert info;

- Include the original psql error message and code in the upsert errors.

This will allow Recombinant to parse the FK constraint error messages, without showing the pSQL error to the user still.