### PR TITLE
Do Not Cache JS i18n API Endpoint

### DIFF
--- a/changes/209.canada.changes
+++ b/changes/209.canada.changes
@@ -1,0 +1,1 @@
+The JS i18n API endpoint is no longer cache-able.

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -27,6 +27,10 @@ from ckan.lib.search import (
 )
 from ckan.types import Context, Response, ActionResult
 
+# (canada fork only): nocache decorator
+# TODO: upstream contrib??
+from . import nocache_store
+
 
 log = logging.getLogger(__name__)
 
@@ -496,6 +500,7 @@ def snippet(snippet_path: str, ver: int = API_REST_DEFAULT_VERSION) -> str:
     return render(snippet_path, extra_vars=extra_vars)
 
 
+@nocache_store
 def i18n_js_translations(
         lang: str,
         ver: int = API_REST_DEFAULT_VERSION) -> Union[str, Response]:


### PR DESCRIPTION
feat(views): js i18n api;

- No cache, No store on the JS i18n api endpoint.