### PR TITLE
Relative URIs for Resource URLs in SOLR

### DIFF
--- a/changes/211.canada.feature
+++ b/changes/211.canada.feature
@@ -1,0 +1,1 @@
+Resource URLs are now only stored as relative paths in SOLR. The request hostname is prepended during `package_show`

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -128,6 +128,9 @@ def resource_dictize(res: model.Resource, context: Context) -> dict[str, Any]:
     url = resource['url']
     ## for_edit is only called at the times when the dataset is to be edited
     ## in the frontend. Without for_edit the whole qualified url is returned.
+
+    # (canada fork only): do not store qualified URIs in SOLR.
+    #                     NOTE: super important for language domain support!!!
     if resource.get('url_type') == 'upload' and not context.get('for_edit'):
         url = url.rsplit('/')[-1]
         cleaned_name = munge.munge_filename(url)
@@ -135,7 +138,7 @@ def resource_dictize(res: model.Resource, context: Context) -> dict[str, Any]:
                                     id=resource['package_id'],
                                     resource_id=res.id,
                                     filename=cleaned_name,
-                                    qualified=True)
+                                    qualified=False)  # (canada fork only): unqualified
     elif resource['url'] and not urlsplit(url).scheme \
          and not context.get('for_edit'):
         resource['url'] = u'http://' + url.lstrip('/')

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -208,7 +208,9 @@ def rebuild(package_id: Optional[str] = None,
         'model': model,
         'ignore_auth': True,
         'validate': False,
-        'use_cache': False
+        'use_cache': False,
+        # (canada fork only): non-qualified res_url for lang domain support
+        'for_index': True,
     })
 
     if package_id:

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -175,7 +175,9 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
                         'model': model,
                         'ignore_auth': True,
                         'validate': False,
-                        'use_cache': False
+                        'use_cache': False,
+                        # (canada fork only): non-qualified res_url for lang domain support
+                        'for_index': True,
                     }), {'id': entity.id}), operation)
         elif operation == domain_object.DomainObjectOperation.deleted:
             dispatch_by_operation(entity.__class__.__name__,

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -14,6 +14,9 @@ from ckan.common import config, asbool
 import sqlalchemy
 from sqlalchemy import text
 
+# (canada fork only): non-qualified res_url for lang domain support
+from flask import request
+
 
 import ckan
 import ckan.lib.dictization
@@ -1092,6 +1095,19 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
 
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.after_dataset_show(context, package_dict)
+
+    # (canada fork only): non-qualified res_url for lang domain support
+    if not context.get('for_index'):
+        try:
+            current_domain = request.host_url.rstrip('/')
+        except RuntimeError:
+            current_domain = config['ckan.site_url'].rstrip('/')
+        for res_dict in package_dict['resources']:
+            if(
+              res_dict.get('url_type') == 'upload' and
+              res_dict.get('url', '').startswith('/')
+            ):
+                res_dict['url'] = current_domain + res_dict['url']
 
     return package_dict
 


### PR DESCRIPTION
This is a solution to the Resource URLs in https://github.com/open-data/ckanext-language-domains/issues/1

Basically the absolute URI of a resource is not stored in the database, but the res_url is stored in SOLR with a fully qualified URI for upload types. Instead, we modify code here to not store qualified URIs in SOLR and just add the requesting hostname to upload resource types for their download URI. And just add a `for_index` context when indexing packages/resources so that SOLR will always have the relative paths.

I imagine this would kind of break other frameworkable parts of CKAN resource uploader...maybe. So not fitting for upstream contrib.