### PR TITLE
Site Read Only Mode

### DIFF
--- a/changes/219.canada.feature
+++ b/changes/219.canada.feature
@@ -1,0 +1,1 @@
+Added a `ckan.site_read_only` config option which disables `_create`, `_update`, `_patch`, and `_delete` actions for non-sysadmin users.

--- a/changes/219.canada.feature
+++ b/changes/219.canada.feature
@@ -1,1 +1,5 @@
-Added a `ckan.site_read_only` config option which disables `_create`, `_update`, `_patch`, and `_delete` actions for non-sysadmin users.
+Added a `ckan.site_read_only` config option which disables actions causing side effects,
+such as `*_create`, `*_update`, and `*_delete`, for non-sysadmin users.
+
+This setting does not prevent updates to the database from sysadmin users or updates
+that skip the action API, such as collecting page view tracking data.

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -228,7 +228,7 @@ def is_authorized(action: str, context: Context,
         # (canada fork only): site read only mode
         # TODO: upstream contrib!!!
         if config.get('ckan.site_read_only', False):
-            if getattr(p.toolkit.get_action(action), 'side_effect_free', False):
+            if not getattr(p.toolkit.get_action(action), 'side_effect_free', False):
                 return {'success': False,
                         'msg': _('Site is in read only mode')}
 

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -225,6 +225,13 @@ def is_authorized(action: str, context: Context,
                 if not getattr(auth_function, 'auth_sysadmins_check', False):
                     return {'success': True}
 
+        # (canada fork only): site read only mode
+        # TODO: upstream contrib!!!
+        if config.get('ckan.site_read_only', False):
+            if getattr(p.toolkit.get_action(action), 'side_effect_free', False):
+                return {'success': False,
+                        'msg': _('Site is in read only mode')}
+
         # If the auth function is flagged as not allowing anonymous access,
         # and an existing user object is not provided in the context, deny
         # access straight away


### PR DESCRIPTION
feat(logic): read only mode;

- Site read only mode.

Prevent non-sysadmin users from doing POST like actions. Idea is to only allow `_show` or `_list` type actions and disallow all `_create`, `_update`, `_patch`, and `_delete` type actions.