### PR TITLE
Creator User ID Schema

### DIFF
--- a/changes/230.canada.feature
+++ b/changes/230.canada.feature
@@ -1,0 +1,1 @@
+Added `creatore_user_id` as a syadmin only field in the Dataset schema, allowing for sysadmins to set this field.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -207,7 +207,9 @@ def package_create(
     if user:
         user_obj = model.User.by_name(six.ensure_text(user))
         if user_obj:
-            data['creator_user_id'] = user_obj.id
+            # (canada fork only): schema for creator_user_id
+            if not data.get('creator_user_id'):
+                data['creator_user_id'] = user_obj.id
             include_plugin_data = user_obj.sysadmin and plugin_data
 
     pkg, _change = model_save.package_dict_save(

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -208,6 +208,7 @@ def package_create(
         user_obj = model.User.by_name(six.ensure_text(user))
         if user_obj:
             # (canada fork only): schema for creator_user_id
+            # TODO: upstream contrib!!
             if not data.get('creator_user_id'):
                 data['creator_user_id'] = user_obj.id
             include_plugin_data = user_obj.sysadmin and plugin_data

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -138,6 +138,7 @@ def default_create_package_schema(
         'name': [
             not_empty, unicode_safe, name_validator, package_name_validator],
         # (canada fork only): schema for creator_user_id
+        # TODO: upstream contrib!!
         'creator_user_id': [ignore_missing, unicode_safe, ignore_not_sysadmin],
         'title': [if_empty_same_as("name"), unicode_safe],
         'author': [ignore_missing, unicode_safe],

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -137,6 +137,8 @@ def default_create_package_schema(
                package_id_does_not_exist],
         'name': [
             not_empty, unicode_safe, name_validator, package_name_validator],
+        # (canada fork only): schema for creator_user_id
+        'creator_user_id': [ignore_missing, unicode_safe, ignore_not_sysadmin],
         'title': [if_empty_same_as("name"), unicode_safe],
         'author': [ignore_missing, unicode_safe],
         'author_email': [ignore_missing, unicode_safe, strip_value,


### PR DESCRIPTION
feat(schema): creator user id;

- Added schema for creator_user_id.

Adds sysadmin only schema for the creator_user_id field for datasets, so sysadmins can modify this field in the framework. Better for site migrations. And I suppose this would also allow for some user migrations for owned datasets at least.