### PR TITLE
Resource View Embed Jinja Blocks

### DIFF
--- a/changes/231.canada.changes
+++ b/changes/231.canada.changes
@@ -1,0 +1,1 @@
+Added template blocks to the Resource View template snippet for plugin extending capabilities, namely for iFrame Embedding.

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -3,16 +3,18 @@
 {% block resource_view %}
   <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <div class="actions">
-    {# (canada fork only): rel='noopener noreferrer' #}
-    {# (canada fork only): non-qualified URIs #}
-    <a class="btn btn-default"
-       target="_blank"
-       rel="noopener noreferrer"
-       href="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=false) }}">
-      <i class="fa fa-arrows-alt"></i>
-      {{ _("Fullscreen") }}
-    </a>
-    {# (canada fork only): remove embed dur to X-Frame-Options:SAMEORIGIN #}
+    {# (canada fork only): jinja-block embed due to X-Frame-Options:SAMEORIGIN #}
+    {% block resource_view_actions %}
+      {# (canada fork only): rel='noopener noreferrer' #}
+      {# (canada fork only): non-qualified URIs #}
+      <a class="btn btn-default"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=false) }}">
+        <i class="fa fa-arrows-alt"></i>
+        {{ _("Fullscreen") }}
+      </a>
+    {% endblock %}
   </div>
   {% block description %}
     <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
@@ -55,7 +57,7 @@
           {% endif %}
         {% else %}
           {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
-            {# (canada fork only): non-qualified URIs #}
+          {# (canada fork only): non-qualified URIs #}
           {% set src = h.url_for(package['type'] ~ '_resource.view', id=package['name'], resource_id=resource['id'], qualified=false) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
         {% endif %}
         {# add lazy loading via data-viewer module (canada fork only) TODO: upstream contribution?? #}
@@ -64,6 +66,7 @@
         </iframe>
       {% endif %}
     </div>
-    {# (canada fork only): remove embed dur to X-Frame-Options:SAMEORIGIN #}
+    {# (canada fork only): jinja-block embed due to X-Frame-Options:SAMEORIGIN #}
+    {% block resource_view_bottom %}{% endblock %}
   </div>
 {% endblock %}


### PR DESCRIPTION
feat(templates): blocks;

- Added jinja blocks for plugin extending.

kinda only want to show the embed in the Public Portal and not Registry, hence the blocks and not directly modifying in here.