### PR TITLE
Feeds Generate Atom IDs Implement

### DIFF
--- a/changes/232.canada.feature
+++ b/changes/232.canada.feature
@@ -1,0 +1,1 @@
+Added a `create_atom_id` implement method to the `IFeed` implement class. This allows for plugins to customize the generation of Atom entry IDs.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -206,6 +206,13 @@ class IFeed(Interface):
         """
         return {}
 
+    # (canada fork only): add feed id gen implement method
+    # TODO: upstream contrib!!
+    def create_atom_id(self, atom_id: str, resource_path: str,
+                       authority_name: Optional[str] = None,
+                       date_string: Optional[str] = None) -> str:
+        pass
+
 
 class IResourceUrlChange(Interface):
     u'''

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -836,8 +836,16 @@ def _create_atom_id(resource_path: str,
         return u''.join([site_url, resource_path])
 
     tagging_entity = u','.join([authority_name, date_string])
-    return u':'.join(['tag', tagging_entity, resource_path])
+    # (canada fork only): add feed id gen implement method
+    # TODO: upstream contrib!!
+    atom_id = ':'.join(['tag', tagging_entity, resource_path])
 
+    for plugin in plugins.PluginImplementations(plugins.IFeed):
+        if hasattr(plugin, 'create_atom_id'):
+            atom_id = plugin.create_atom_id(
+                atom_id, resource_path, authority_name, date_string)
+
+    return atom_id
 
 # Routing
 # (canada fork only): custom single dataset feed


### PR DESCRIPTION
feat(dev): feeds implement;

- New method implement for IFeeds.

the feeds code is really old, and does not always fit into the CKAN framework or CKAN pythonian stacks/loads. So implements are the easiest/best IMHO